### PR TITLE
Document type conversion fix for WHERE...IN clauses

### DIFF
--- a/postgres-types/src/lib.rs
+++ b/postgres-types/src/lib.rs
@@ -858,6 +858,9 @@ pub enum IsNull {
 /// `ToSql` is implemented for `[u8; N]`, `Vec<T>`, `&[T]`, `Box<[T]>` and `[T; N]`
 /// where `T` implements `ToSql` and `N` is const usize, and corresponds to one-dimensional
 /// Postgres arrays with an index offset of 1.
+/// To make conversion work correctly for `WHERE ... IN` clauses, for example
+/// `WHERE col IN ($1)`, you may instead have to use the construct
+/// `WHERE col = ANY ($1)` which expects an array.
 ///
 /// **Note:** the impl for arrays only exist when the Cargo feature `array-impls`
 /// is enabled.


### PR DESCRIPTION
This otherwise fails at runtime (tested against CockroachDB):

```rust
let mut uuids = Vec::<Uuid>::new();
// ...
db_tx.execute("DELETE FROM mytab WHERE the_uuid_column IN ($1)", &[&uuids])?;
```

```
Error { kind: ToSql(1), cause: Some(WrongType { postgres: Uuid, rust: \"alloc::vec::Vec<uuid::Uuid>\" }) }: error serializing parameter 1: cannot convert between the Rust type `alloc::vec::Vec<uuid::Uuid>` and the Postgres type `uuid`
```

The `= ANY ($1)` construct makes it work.

Since I couldn't find the answer directly, maybe we can add this hint to the documentation? It also applies to [other client libraries](https://stackoverflow.com/questions/53280333/javascript-postgres-db-how-to-use-a-prepared-statement-with-an-array-as-para).