### PR TITLE
expose sync rollback as a private api method

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -603,11 +603,6 @@ impl Client {
     }
 
     #[doc(hidden)]
-    pub fn __private_api_close(&mut self) {
-        self.inner.sender.close_channel()
-    }
-
-    #[doc(hidden)]
     pub fn __private_api_rollback(&self, name: Option<&str>) {
         let buf = self.inner().with_buf(|buf| {
             if let Some(name) = name {
@@ -620,6 +615,11 @@ impl Client {
         let _ = self
             .inner()
             .send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+    }
+
+    #[doc(hidden)]
+    pub fn __private_api_close(&mut self) {
+        self.inner.sender.close_channel()
     }
 }
 

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -1,5 +1,3 @@
-use crate::codec::FrontendMessage;
-use crate::connection::RequestMessages;
 use crate::copy_out::CopyOutStream;
 use crate::query::RowStream;
 #[cfg(feature = "runtime")]
@@ -14,7 +12,6 @@ use crate::{
 };
 use bytes::Buf;
 use futures_util::TryStreamExt;
-use postgres_protocol::message::frontend;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// A representation of a PostgreSQL database transaction.
@@ -39,19 +36,8 @@ impl Drop for Transaction<'_> {
             return;
         }
 
-        let query = if let Some(sp) = self.savepoint.as_ref() {
-            format!("ROLLBACK TO {}", sp.name)
-        } else {
-            "ROLLBACK".to_string()
-        };
-        let buf = self.client.inner().with_buf(|buf| {
-            frontend::query(&query, buf).unwrap();
-            buf.split().freeze()
-        });
-        let _ = self
-            .client
-            .inner()
-            .send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+        let name = self.savepoint.as_ref().map(|sp| sp.name.as_str());
+        self.client.__private_api_rollback(name);
     }
 }
 

--- a/tokio-postgres/src/transaction_builder.rs
+++ b/tokio-postgres/src/transaction_builder.rs
@@ -1,6 +1,4 @@
-use postgres_protocol::message::frontend;
-
-use crate::{codec::FrontendMessage, connection::RequestMessages, Client, Error, Transaction};
+use crate::{Client, Error, Transaction};
 
 /// The isolation level of a database transaction.
 #[derive(Debug, Copy, Clone)]
@@ -119,14 +117,7 @@ impl<'a> TransactionBuilder<'a> {
                     return;
                 }
 
-                let buf = self.client.inner().with_buf(|buf| {
-                    frontend::query("ROLLBACK", buf).unwrap();
-                    buf.split().freeze()
-                });
-                let _ = self
-                    .client
-                    .inner()
-                    .send(RequestMessages::Single(FrontendMessage::Raw(buf)));
+                self.client.__private_api_rollback(None);
             }
         }
 


### PR DESCRIPTION
Don't know if this is the correct approach, I just saw that sync close was exposed the same way.

It would be useful to have this exposed so that one can implement their own transaction type with a drop implementation that rolls back.

The reason I would like to implement my own transaction type is that I want to expose it to nodejs via napi-rs, and it is not possible to share things that have a lifetime over that boundary.