### PR TITLE
tokio-postgres: Fix test assertion, document existing support for `cidr 0.3`

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -107,6 +107,7 @@
 //! | `array-impls` | Enables `ToSql` and `FromSql` trait impls for arrays | - | no |
 //! | `with-bit-vec-0_6` | Enable support for the `bit-vec` crate. | [bit-vec](https://crates.io/crates/bit-vec) 0.6 | no |
 //! | `with-chrono-0_4` | Enable support for the `chrono` crate. | [chrono](https://crates.io/crates/chrono) 0.4 | no |
+//! | `with-cidr-0_3` | Enable support for the `cidr` crate. | [cidr](https://crates.io/crates/cidr) 0.3 | no |
 //! | `with-eui48-0_4` | Enable support for the 0.4 version of the `eui48` crate. This is deprecated and will be removed. | [eui48](https://crates.io/crates/eui48) 0.4 | no |
 //! | `with-eui48-1` | Enable support for the 1.0 version of the `eui48` crate. | [eui48](https://crates.io/crates/eui48) 1.0 | no |
 //! | `with-geo-types-0_6` | Enable support for the 0.6 version of the `geo-types` crate. | [geo-types](https://crates.io/crates/geo-types/0.6.0) 0.6 | no |

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -928,7 +928,7 @@ async fn query_opt() {
         .unwrap()
         .unwrap();
     client
-        .query_one("SELECT * FROM foo", &[])
+        .query_opt("SELECT * FROM foo", &[])
         .await
         .err()
         .unwrap();


### PR DESCRIPTION
Addresses two minor issues:

1. Fixes a test for `query_opt` that currently calls `query_one`
2. Adds missing documentation for the `with-cidr-0_3` feature, which though fully-functional is not referenced in the docs