### PR TITLE
Disable default features of `futures-util`

### DIFF
--- a/postgres-native-tls/Cargo.toml
+++ b/postgres-native-tls/Cargo.toml
@@ -22,6 +22,6 @@ tokio-native-tls = "0.3"
 tokio-postgres = { version = "0.7.11", path = "../tokio-postgres", default-features = false }
 
 [dev-dependencies]
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1.0", features = ["macros", "net", "rt"] }
 postgres = { version = "0.19.8", path = "../postgres" }

--- a/postgres-openssl/Cargo.toml
+++ b/postgres-openssl/Cargo.toml
@@ -22,6 +22,6 @@ tokio-openssl = "0.6"
 tokio-postgres = { version = "0.7.11", path = "../tokio-postgres", default-features = false }
 
 [dev-dependencies]
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1.0", features = ["macros", "net", "rt"] }
 postgres = { version = "0.19.8", path = "../postgres" }

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -54,7 +54,7 @@ bytes = "1.0"
 byteorder = "1.0"
 fallible-iterator = "0.2"
 futures-channel = { version = "0.3", features = ["sink"] }
-futures-util = { version = "0.3", features = ["sink"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 log = "0.4"
 parking_lot = "0.12"
 percent-encoding = "2.0"
@@ -71,6 +71,7 @@ whoami = "1.4.1"
 socket2 = { version = "0.5", features = ["all"] }
 
 [dev-dependencies]
+futures-util = { version = "0.3", default-features = false, features = ["async-await-macro"] }
 futures-executor = "0.3"
 criterion = "0.6"
 env_logger = "0.11"


### PR DESCRIPTION
`futures-util` enables many features by default which make the crate heavy to compile. This disables default features, greatly improving build speed. I've manually verified that the most commonly used features (`alloc` and `std`) weren't necessary for this project.