### PR TITLE
Re-export FallibleIterator from tokio-postgres

### DIFF
--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -142,6 +142,7 @@ pub use crate::to_statement::ToStatement;
 pub use crate::transaction::Transaction;
 pub use crate::transaction_builder::{IsolationLevel, TransactionBuilder};
 use crate::types::ToSql;
+pub use fallible_iterator;
 use std::sync::Arc;
 
 pub mod binary_copy;


### PR DESCRIPTION
Allows wasm users to import FallibleIterator via tokio-postgres instead
of having to define the dependency themselves.

Fixes #1210
