### PR TITLE
Remove mentions of require-full and require-ca

### DIFF
--- a/tokio-postgres/src/connect_tls.rs
+++ b/tokio-postgres/src/connect_tls.rs
@@ -24,7 +24,7 @@ where
             return Ok(MaybeTlsStream::Raw(stream))
         }
         SslMode::Prefer if negotiation == SslNegotiation::Direct => {
-            return Err(Error::tls("weak sslmode \"prefer\" may not be used with sslnegotiation=direct (use \"require\", \"verify-ca\", or \"verify-full\")".into()))
+            return Err(Error::tls("weak sslmode \"prefer\" may not be used with sslnegotiation=direct (use \"require\")".into()))
         }
         SslMode::Prefer | SslMode::Require => {}
     }


### PR DESCRIPTION
Both of the options are not valid in rust-postgres and they are not supported.

Actually rust-postgres deviates from postgres docs by checking the certificate when specifying "require".

related: https://github.com/sfackler/rust-postgres/pull/988

Would it make sense to parse "require-full" into SslMode:Require? That would make it compatible with normal postgres connection URLs


cc @nyurik hi! nice to see you here!