### PR TITLE
Switch `serde` dependency to `serde_core`

### DIFF
--- a/postgres-types/Cargo.toml
+++ b/postgres-types/Cargo.toml
@@ -56,8 +56,8 @@ geo-types-06 = { version = "0.6", package = "geo-types", optional = true }
 geo-types-0_7 = { version = "0.7", package = "geo-types", optional = true }
 jiff-01 = { version = "0.1", package = "jiff", optional = true }
 jiff-02 = { version = "0.2", package = "jiff", optional = true }
-serde-1 = { version = "1.0", package = "serde", optional = true }
-serde_json-1 = { version = "1.0", package = "serde_json", optional = true }
+serde-1 = { version = "1.0.221", package = "serde_core", optional = true }
+serde_json-1 = { version = "1.0.144", package = "serde_json", optional = true }
 uuid-08 = { version = "0.8", package = "uuid", optional = true }
 uuid-1 = { version = "1.0", package = "uuid", optional = true }
 time-02 = { version = "0.2", package = "time", optional = true }

--- a/postgres-types/src/serde_json_1.rs
+++ b/postgres-types/src/serde_json_1.rs
@@ -1,15 +1,26 @@
 use crate::{FromSql, IsNull, ToSql, Type};
 use bytes::{BufMut, BytesMut};
-use serde_1::{Deserialize, Serialize};
+use serde_1::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json_1::Value;
 use std::error::Error;
 use std::fmt::Debug;
 use std::io::Read;
 
 /// A wrapper type to allow arbitrary `Serialize`/`Deserialize` types to convert to Postgres JSON values.
-#[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(crate = "serde_1", transparent)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Json<T>(pub T);
+
+impl<T: Serialize> Serialize for Json<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Json<T> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        T::deserialize(deserializer).map(Self)
+    }
+}
 
 impl<'a, T> FromSql<'a> for Json<T>
 where

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -92,7 +92,6 @@ geo-types-06 = { version = "0.6", package = "geo-types" }
 geo-types-07 = { version = "0.7", package = "geo-types" }
 jiff-01 = { version = "0.1", package = "jiff" }
 jiff-02 = { version = "0.2", package = "jiff" }
-serde-1 = { version = "1.0", package = "serde" }
 serde_json-1 = { version = "1.0", package = "serde_json" }
 smol_str-01 = { version = "0.1", package = "smol_str" }
 uuid-08 = { version = "0.8", package = "uuid" }


### PR DESCRIPTION
This project doesn't need `serde-derive` macros, so it can depend on `serde_core` instead of `serde` and be faster to build as a result. More info in https://crates.io/crates/serde_core.