### PR TITLE
`FromRow` mapping and `query_*_as` convenience methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,7 @@ name = "postgres-derive"
 version = "0.4.9"
 dependencies = [
  "heck",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 3.0.0",
@@ -1210,6 +1211,7 @@ version = "0.1.0"
 dependencies = [
  "postgres",
  "postgres-types",
+ "tokio-postgres",
  "trybuild",
 ]
 
@@ -1299,6 +1301,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1927,6 +1938,7 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project-lite",
+ "postgres-derive",
  "postgres-protocol",
  "postgres-types",
  "rand",
@@ -1977,6 +1989,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
 ]
 
 [[package]]
@@ -2413,6 +2437,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/postgres-derive-test/Cargo.toml
+++ b/postgres-derive-test/Cargo.toml
@@ -8,5 +8,7 @@ rust-version = "1.85"
 [dev-dependencies]
 trybuild = "1.0.18"
 
+# Using a Rust keyword as the dependency alias to exercise derive path hygiene.
+type = { version = "0.7.18", package = "tokio-postgres", default-features = false, features = ["derive"], path = "../tokio-postgres" }
 postgres-types = { path = "../postgres-types", features = ["derive"] }
 postgres = { path = "../postgres" }

--- a/postgres-derive-test/src/from_row/fail/borrowed_query.rs
+++ b/postgres-derive-test/src/from_row/fail/borrowed_query.rs
@@ -1,0 +1,12 @@
+use r#type::{Client, FromRow};
+
+#[derive(FromRow)]
+struct User<'a> {
+    name: &'a str,
+}
+
+fn load(client: &Client) {
+    let _future = client.query_one_as::<User<'_>>("SELECT name FROM users", &[]);
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/borrowed_query.stderr
+++ b/postgres-derive-test/src/from_row/fail/borrowed_query.stderr
@@ -1,0 +1,8 @@
+error: implementation of `FromRow` is not general enough
+ --> src/from_row/fail/borrowed_query.rs:9:19
+  |
+9 |     let _future = client.query_one_as::<User<'_>>("SELECT name FROM users", &[]);
+  |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `FromRow` is not general enough
+  |
+  = note: `User<'_>` must implement `FromRow<'0>`, for any lifetime `'0`...
+  = note: ...but `User<'_>` actually implements `FromRow<'1>`, for some specific lifetime `'1`

--- a/postgres-derive-test/src/from_row/fail/invalid_rename_rule.rs
+++ b/postgres-derive-test/src/from_row/fail/invalid_rename_rule.rs
@@ -1,0 +1,9 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+#[postgres(rename_all = "invalid")]
+struct User {
+    id: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/invalid_rename_rule.stderr
+++ b/postgres-derive-test/src/from_row/fail/invalid_rename_rule.stderr
@@ -1,0 +1,5 @@
+error: invalid rename_all rule, expected one of: "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE", "Train-Case"
+ --> src/from_row/fail/invalid_rename_rule.rs:4:25
+  |
+4 | #[postgres(rename_all = "invalid")]
+  |                         ^^^^^^^^^

--- a/postgres-derive-test/src/from_row/fail/non_string_name.rs
+++ b/postgres-derive-test/src/from_row/fail/non_string_name.rs
@@ -1,0 +1,9 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+struct User {
+    #[postgres(name = 1)]
+    id: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/non_string_name.stderr
+++ b/postgres-derive-test/src/from_row/fail/non_string_name.stderr
@@ -1,0 +1,5 @@
+error: expected a string literal
+ --> src/from_row/fail/non_string_name.rs:5:23
+  |
+5 |     #[postgres(name = 1)]
+  |                       ^

--- a/postgres-derive-test/src/from_row/fail/non_string_rename_all.rs
+++ b/postgres-derive-test/src/from_row/fail/non_string_rename_all.rs
@@ -1,0 +1,9 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+#[postgres(rename_all = 1)]
+struct User {
+    id: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/non_string_rename_all.stderr
+++ b/postgres-derive-test/src/from_row/fail/non_string_rename_all.stderr
@@ -1,0 +1,5 @@
+error: expected a string literal
+ --> src/from_row/fail/non_string_rename_all.rs:4:25
+  |
+4 | #[postgres(rename_all = 1)]
+  |                         ^

--- a/postgres-derive-test/src/from_row/fail/rename_all_on_field.rs
+++ b/postgres-derive-test/src/from_row/fail/rename_all_on_field.rs
@@ -1,0 +1,9 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+struct User {
+    #[postgres(rename_all = "camelCase")]
+    id: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/rename_all_on_field.stderr
+++ b/postgres-derive-test/src/from_row/fail/rename_all_on_field.stderr
@@ -1,0 +1,5 @@
+error: rename_all is a container attribute
+ --> src/from_row/fail/rename_all_on_field.rs:5:16
+  |
+5 |     #[postgres(rename_all = "camelCase")]
+  |                ^^^^^^^^^^

--- a/postgres-derive-test/src/from_row/fail/type_only_options.rs
+++ b/postgres-derive-test/src/from_row/fail/type_only_options.rs
@@ -1,0 +1,27 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+#[postgres(transparent)]
+struct TransparentContainer {
+    value: i64,
+}
+
+#[derive(FromRow)]
+#[postgres(allow_mismatch)]
+struct MismatchedContainer {
+    value: i64,
+}
+
+#[derive(FromRow)]
+struct TransparentField {
+    #[postgres(transparent)]
+    value: i64,
+}
+
+#[derive(FromRow)]
+struct MismatchedField {
+    #[postgres(allow_mismatch)]
+    value: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/type_only_options.stderr
+++ b/postgres-derive-test/src/from_row/fail/type_only_options.stderr
@@ -1,0 +1,23 @@
+error: unknown attribute
+ --> src/from_row/fail/type_only_options.rs:4:12
+  |
+4 | #[postgres(transparent)]
+  |            ^^^^^^^^^^^
+
+error: unknown attribute
+  --> src/from_row/fail/type_only_options.rs:10:12
+   |
+10 | #[postgres(allow_mismatch)]
+   |            ^^^^^^^^^^^^^^
+
+error: unknown attribute
+  --> src/from_row/fail/type_only_options.rs:17:16
+   |
+17 |     #[postgres(transparent)]
+   |                ^^^^^^^^^^^
+
+error: unknown attribute
+  --> src/from_row/fail/type_only_options.rs:23:16
+   |
+23 |     #[postgres(allow_mismatch)]
+   |                ^^^^^^^^^^^^^^

--- a/postgres-derive-test/src/from_row/fail/unknown_container_attr.rs
+++ b/postgres-derive-test/src/from_row/fail/unknown_container_attr.rs
@@ -1,0 +1,9 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+#[postgres(foo = "bar")]
+struct User {
+    id: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/unknown_container_attr.stderr
+++ b/postgres-derive-test/src/from_row/fail/unknown_container_attr.stderr
@@ -1,0 +1,5 @@
+error: unknown override
+ --> src/from_row/fail/unknown_container_attr.rs:4:12
+  |
+4 | #[postgres(foo = "bar")]
+  |            ^^^

--- a/postgres-derive-test/src/from_row/fail/unknown_field_attr.rs
+++ b/postgres-derive-test/src/from_row/fail/unknown_field_attr.rs
@@ -1,0 +1,9 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+struct User {
+    #[postgres(foo = "bar")]
+    id: i64,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/unknown_field_attr.stderr
+++ b/postgres-derive-test/src/from_row/fail/unknown_field_attr.stderr
@@ -1,0 +1,5 @@
+error: unknown override
+ --> src/from_row/fail/unknown_field_attr.rs:5:16
+  |
+5 |     #[postgres(foo = "bar")]
+  |                ^^^

--- a/postgres-derive-test/src/from_row/fail/unsupported_shape.rs
+++ b/postgres-derive-test/src/from_row/fail/unsupported_shape.rs
@@ -1,0 +1,19 @@
+use r#type::FromRow;
+
+#[derive(FromRow)]
+struct User(i64);
+
+#[derive(FromRow)]
+struct Unit;
+
+#[derive(FromRow)]
+enum Enumeration {
+    Value { id: i32 },
+}
+
+#[derive(FromRow)]
+union Union {
+    id: i32,
+}
+
+fn main() {}

--- a/postgres-derive-test/src/from_row/fail/unsupported_shape.stderr
+++ b/postgres-derive-test/src/from_row/fail/unsupported_shape.stderr
@@ -1,0 +1,27 @@
+error: #[derive(FromRow)] may only be applied to structs with named fields
+ --> src/from_row/fail/unsupported_shape.rs:4:1
+  |
+4 | struct User(i64);
+  | ^^^^^^^^^^^^^^^^^
+
+error: #[derive(FromRow)] may only be applied to structs with named fields
+ --> src/from_row/fail/unsupported_shape.rs:7:1
+  |
+7 | struct Unit;
+  | ^^^^^^^^^^^^
+
+error: #[derive(FromRow)] may only be applied to structs with named fields
+  --> src/from_row/fail/unsupported_shape.rs:10:1
+   |
+10 | / enum Enumeration {
+11 | |     Value { id: i32 },
+12 | | }
+   | |_^
+
+error: #[derive(FromRow)] may only be applied to structs with named fields
+  --> src/from_row/fail/unsupported_shape.rs:15:1
+   |
+15 | / union Union {
+16 | |     id: i32,
+17 | | }
+   | |_^

--- a/postgres-derive-test/src/from_row/pass/basic.rs
+++ b/postgres-derive-test/src/from_row/pass/basic.rs
@@ -1,0 +1,232 @@
+#![allow(non_upper_case_globals)]
+
+use std::rc::Rc;
+
+use postgres_types::{FromSql, ToSql};
+use tokio_pg::{FromRow, GenericClient};
+use r#type as tokio_pg;
+
+#[derive(FromRow)]
+struct User {
+    id: i64,
+    name: String,
+}
+
+#[derive(FromRow)]
+struct Empty {}
+
+#[derive(FromRow)]
+struct Renamed {
+    #[postgres(name = "user_id")]
+    id: i64,
+}
+
+#[derive(FromRow)]
+#[postgres(rename_all = "camelCase")]
+struct AuditLog {
+    actor_id: i64,
+}
+
+#[derive(FromRow)]
+struct Borrowed<'a> {
+    name: &'a str,
+    data: &'a [u8],
+}
+
+#[derive(FromRow)]
+struct MultipleBorrowed<'a, 'b> {
+    name: &'a str,
+    data: &'b [u8],
+}
+
+#[derive(FromRow)]
+struct RowLifetimeCollision<'__tokio_postgres_row> {
+    value: &'__tokio_postgres_row str,
+}
+
+#[derive(FromRow)]
+struct MultipleLifetimeCollisions<'__tokio_postgres_row, '__tokio_postgres_row1> {
+    name: &'__tokio_postgres_row str,
+    data: &'__tokio_postgres_row1 [u8],
+}
+
+#[derive(FromRow)]
+struct ConstNameCollision<const row: usize> {
+    value: i32,
+}
+
+#[derive(FromRow)]
+struct RowField {
+    row: i32,
+    value: i32,
+}
+
+#[derive(FromRow)]
+struct Generic<T> {
+    value: T,
+}
+
+struct Wrapper<T>(T);
+
+impl<'a, T> tokio_pg::types::FromSql<'a> for Wrapper<T> {
+    fn from_sql(
+        _: &tokio_pg::types::Type,
+        _: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        unimplemented!()
+    }
+
+    fn accepts(_: &tokio_pg::types::Type) -> bool {
+        true
+    }
+}
+
+#[derive(FromRow)]
+struct WrappedGeneric<T> {
+    value: Wrapper<T>,
+}
+
+#[derive(FromRow)]
+struct IndependentLifetime<'a> {
+    value: Wrapper<&'a ()>,
+}
+
+#[derive(FromRow)]
+struct HigherRankedCollision {
+    value: Wrapper<for<'__tokio_postgres_row> fn(&'__tokio_postgres_row str)>,
+}
+
+#[derive(FromRow)]
+struct HigherRankedBoundCollision<T>
+where
+    T: for<'__tokio_postgres_row> Fn(&'__tokio_postgres_row str),
+{
+    value: Wrapper<T>,
+}
+
+#[derive(FromRow)]
+struct DefaultGenerics<T = i32, const N: usize = 3> {
+    value: Wrapper<[T; N]>,
+}
+
+trait HasValue {
+    type Value;
+}
+
+#[derive(FromRow)]
+struct AssociatedType<T: HasValue> {
+    value: T::Value,
+}
+
+#[derive(Debug, FromRow, FromSql, ToSql)]
+#[postgres(name = "shared_composite")]
+struct SharedComposite {
+    value: i32,
+}
+
+fn assert_from_row<'a, T>()
+where
+    T: FromRow<'a>,
+{
+}
+
+fn assert_generic<'a, T>()
+where
+    T: tokio_pg::types::FromSql<'a>,
+{
+    assert_from_row::<Generic<T>>();
+}
+
+fn assert_wrapped_generic<T>() {
+    assert_owned_from_row::<WrappedGeneric<T>>();
+}
+
+fn assert_associated_type<T>()
+where
+    T: HasValue,
+    T::Value: for<'a> FromSql<'a>,
+{
+    assert_owned_from_row::<AssociatedType<T>>();
+}
+
+fn assert_owned_from_row<T>()
+where
+    T: for<'a> FromRow<'a>,
+{
+}
+
+fn assert_multiple_borrowed<'a>() {
+    assert_from_row::<MultipleBorrowed<'a, 'a>>();
+}
+
+async fn assert_client_methods(
+    client: &tokio_pg::Client,
+    statement: &tokio_pg::Statement,
+) -> Result<(), tokio_pg::Error> {
+    let _: Vec<User> = client
+        .query_as::<User>("SELECT id, name FROM users", &[])
+        .await?;
+    let _: User = client.query_one_as::<User>(statement, &[]).await?;
+    let _: Option<User> = client
+        .query_opt_as::<User>("SELECT id, name FROM users WHERE id = $1", &[&1i64])
+        .await?;
+
+    Ok(())
+}
+
+async fn assert_transaction_methods(
+    transaction: &tokio_pg::Transaction<'_>,
+    statement: &tokio_pg::Statement,
+) -> Result<(), tokio_pg::Error> {
+    let _: Vec<User> = transaction
+        .query_as::<User>("SELECT id, name FROM users", &[])
+        .await?;
+    let _: User = transaction.query_one_as::<User>(statement, &[]).await?;
+    let _: Option<User> = transaction
+        .query_opt_as::<User>("SELECT id, name FROM users WHERE id = $1", &[&1i64])
+        .await?;
+
+    Ok(())
+}
+
+async fn assert_generic_client_methods<C>(
+    client: &C,
+    statement: &tokio_pg::Statement,
+) -> Result<(), tokio_pg::Error>
+where
+    C: GenericClient,
+{
+    let _: Vec<User> = client
+        .query_as::<User>("SELECT id, name FROM users", &[])
+        .await?;
+    let _: User = client.query_one_as::<User>(statement, &[]).await?;
+    let _: Option<User> = client
+        .query_opt_as::<User>("SELECT id, name FROM users WHERE id = $1", &[&1i64])
+        .await?;
+
+    let _: Vec<WrappedGeneric<Rc<()>>> = client.query_as("SELECT value", &[]).await?;
+    let _: WrappedGeneric<Rc<()>> = client.query_one_as("SELECT value", &[]).await?;
+    let _: Option<WrappedGeneric<Rc<()>>> = client.query_opt_as("SELECT value", &[]).await?;
+
+    Ok(())
+}
+
+fn main() {
+    assert_owned_from_row::<Empty>();
+    assert_from_row::<User>();
+    assert_from_row::<Renamed>();
+    assert_from_row::<AuditLog>();
+    assert_from_row::<Borrowed<'_>>();
+    assert_from_row::<SharedComposite>();
+    assert_from_row::<RowLifetimeCollision<'_>>();
+    assert_from_row::<MultipleLifetimeCollisions<'_, '_>>();
+    assert_owned_from_row::<ConstNameCollision<1>>();
+    assert_owned_from_row::<RowField>();
+    assert_owned_from_row::<HigherRankedCollision>();
+    assert_owned_from_row::<HigherRankedBoundCollision<fn(&str)>>();
+    assert_owned_from_row::<DefaultGenerics>();
+    assert_owned_from_row::<DefaultGenerics<Rc<()>, 0>>();
+    assert_generic::<i64>();
+    assert_wrapped_generic::<()>();
+    assert_owned_from_row::<IndependentLifetime<'static>>();
+}

--- a/postgres-derive-test/src/lib.rs
+++ b/postgres-derive-test/src/lib.rs
@@ -55,3 +55,11 @@ pub fn test_type_asymmetric<T, F, S, C>(
 fn compile_fail() {
     trybuild::TestCases::new().compile_fail("src/compile-fail/*.rs");
 }
+
+#[test]
+fn from_row() {
+    let tests = trybuild::TestCases::new();
+    tests.pass("src/from_row/pass/*.rs");
+    // Capturing compiler diagnostics with `TRYBUILD=overwrite cargo +1.85.0 test -p postgres-derive-test from_row`.
+    tests.compile_fail("src/from_row/fail/*.rs");
+}

--- a/postgres-derive/CHANGELOG.md
+++ b/postgres-derive/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+* Added a derive macro for `tokio_postgres::FromRow` behind the `from-row` feature.
+
 ## v0.4.9 - 2026-06-12
 
 ### Fixed

--- a/postgres-derive/Cargo.toml
+++ b/postgres-derive/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.4.9"
 authors = ["Steven Fackler <sfackler@palantir.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"
-description = "An internal crate used by postgres-types"
+description = "An internal crate used by postgres-types and tokio-postgres"
 repository = "https://github.com/rust-postgres/rust-postgres"
 rust-version = "1.85"
 
@@ -12,8 +12,12 @@ rust-version = "1.85"
 proc-macro = true
 test = false
 
+[features]
+from-row = ["dep:proc-macro-crate"]
+
 [dependencies]
 syn = "3.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 heck = "0.5"
+proc-macro-crate = { version = "3.5", optional = true }

--- a/postgres-derive/src/composites.rs
+++ b/postgres-derive/src/composites.rs
@@ -1,11 +1,13 @@
 use proc_macro2::Span;
 use syn::{
-    Error, GenericParam, Generics, Ident, Path, PathSegment, Type, TypeParamBound,
+    Error, GenericParam, Generics, Ident, Path, PathSegment, Type, TypeParamBound, ext::IdentExt,
     punctuated::Punctuated,
 };
 
-use crate::{case::RenameRule, overrides::Overrides};
+use crate::case::RenameRule;
+use crate::overrides::{Derive, Overrides};
 
+/// Named Rust field mapped to a PostgreSQL composite field or row column.
 pub struct Field {
     pub name: String,
     pub ident: Ident,
@@ -13,20 +15,22 @@ pub struct Field {
 }
 
 impl Field {
-    pub fn parse(raw: &syn::Field, rename_all: Option<RenameRule>) -> Result<Field, Error> {
-        let overrides = Overrides::extract(&raw.attrs, false)?;
+    pub fn parse(
+        raw: &syn::Field,
+        rename_all: Option<RenameRule>,
+        derive: Derive,
+    ) -> Result<Field, Error> {
+        let overrides = Overrides::extract(&raw.attrs, false, derive)?;
         let ident = raw.ident.as_ref().unwrap().clone();
 
-        // field level name override takes precendence over container level rename_all override
         let name = match overrides.name {
             Some(n) => n,
             None => {
-                let name = ident.to_string();
-                let stripped = name.strip_prefix("r#").map(String::from).unwrap_or(name);
+                let name = ident.unraw().to_string();
 
                 match rename_all {
-                    Some(rule) => rule.apply_to_field(&stripped),
-                    None => stripped,
+                    Some(rule) => rule.apply_to_field(&name),
+                    None => name,
                 }
             }
         };

--- a/postgres-derive/src/enums.rs
+++ b/postgres-derive/src/enums.rs
@@ -1,6 +1,7 @@
 use syn::{Error, Fields, Ident};
 
-use crate::{case::RenameRule, overrides::Overrides};
+use crate::case::RenameRule;
+use crate::overrides::{Derive, Overrides};
 
 pub struct Variant {
     pub ident: Ident,
@@ -18,9 +19,8 @@ impl Variant {
                 ));
             }
         }
-        let overrides = Overrides::extract(&raw.attrs, false)?;
+        let overrides = Overrides::extract(&raw.attrs, false, Derive::Sql)?;
 
-        // variant level name override takes precendence over container level rename_all override
         let name = overrides.name.unwrap_or_else(|| match rename_all {
             Some(rule) => rule.apply_to_field(&raw.ident.to_string()),
             None => raw.ident.to_string(),

--- a/postgres-derive/src/from_row.rs
+++ b/postgres-derive/src/from_row.rs
@@ -1,0 +1,112 @@
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::{Span, TokenStream, TokenTree};
+use quote::{ToTokens, format_ident, quote};
+use syn::{
+    Data, DataStruct, DeriveInput, Error, Fields, GenericParam, Ident, Lifetime, LifetimeParam,
+    ext::IdentExt, parse_quote,
+};
+
+use crate::composites::Field;
+use crate::overrides::{Derive, Overrides};
+
+pub fn expand_derive_from_row(input: DeriveInput) -> Result<TokenStream, Error> {
+    let overrides = Overrides::extract(&input.attrs, true, Derive::Row)?;
+
+    let Data::Struct(DataStruct {
+        fields: Fields::Named(fields),
+        ..
+    }) = &input.data
+    else {
+        return Err(Error::new_spanned(
+            &input,
+            "#[derive(FromRow)] may only be applied to structs with named fields",
+        ));
+    };
+    let fields = fields
+        .named
+        .iter()
+        .map(|field| Field::parse(field, overrides.rename_all, Derive::Row))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let ident = &input.ident;
+    let postgres = postgres_path(ident.span())?;
+    let prefix = private_prefix(&input);
+    let row = format_ident!("{prefix}_row");
+    // Adding a separate lifetime; the struct's own lifetimes need not borrow from the row.
+    let row_lifetime = Lifetime::new(&format!("'{row}"), Span::call_site());
+    let mut generics = input.generics.clone();
+    generics.params.insert(
+        0,
+        GenericParam::Lifetime(LifetimeParam::new(row_lifetime.clone())),
+    );
+
+    // Bounding field types; a wrapper may decode without its type parameters implementing FromSql.
+    for field in &fields {
+        let field_type = &field.type_;
+        generics
+            .make_where_clause()
+            .predicates
+            .push(parse_quote!(#field_type: #postgres::types::FromSql<#row_lifetime>));
+    }
+
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+    let (_, type_generics, _) = input.generics.split_for_impl();
+    let field_idents = fields.iter().map(|field| &field.ident);
+    let field_names = fields.iter().map(|field| &field.name);
+    let field_types = fields.iter().map(|field| &field.type_);
+    let field_bindings = (0..fields.len())
+        .map(|index| format_ident!("{prefix}_field{index}"))
+        .collect::<Vec<_>>();
+
+    Ok(quote! {
+        impl #impl_generics #postgres::FromRow<#row_lifetime> for #ident #type_generics #where_clause {
+            fn from_row(#row: &#row_lifetime #postgres::Row) -> ::core::result::Result<Self, #postgres::Error> {
+                #(
+                    let #field_bindings = #row.try_get::<_, #field_types>(#field_names)?;
+                )*
+                ::core::result::Result::Ok(Self {
+                    #(
+                        #field_idents: #field_bindings,
+                    )*
+                })
+            }
+        }
+    })
+}
+
+/// Choose a prefix that cannot collide with input bindings or higher-ranked lifetimes.
+fn private_prefix(input: &DeriveInput) -> String {
+    let mut prefix = "__tokio_postgres".to_owned();
+    let mut streams = vec![input.to_token_stream().into_iter()];
+
+    while let Some(stream) = streams.last_mut() {
+        match stream.next() {
+            None => {
+                streams.pop();
+            }
+            Some(TokenTree::Group(group)) => streams.push(group.stream().into_iter()),
+            Some(TokenTree::Ident(ident)) => {
+                let ident = ident.unraw().to_string();
+                while ident.starts_with(&prefix) {
+                    prefix.push('_');
+                }
+            }
+            _ => {}
+        }
+    }
+
+    prefix
+}
+
+/// Resolve the absolute tokio-postgres path using the consuming crate's dependency name.
+fn postgres_path(span: Span) -> Result<TokenStream, Error> {
+    let name = crate_name("tokio-postgres");
+    let name = name.map_err(|error| Error::new(span, error))?;
+    match name {
+        FoundCrate::Itself => Ok(quote!(::tokio_postgres)),
+        FoundCrate::Name(name) => {
+            let name = Ident::new_raw(&name, span);
+            Ok(quote!(::#name))
+        }
+    }
+}

--- a/postgres-derive/src/fromsql.rs
+++ b/postgres-derive/src/fromsql.rs
@@ -12,10 +12,10 @@ use crate::accepts;
 use crate::composites::Field;
 use crate::composites::{append_generic_bound, new_derive_path};
 use crate::enums::Variant;
-use crate::overrides::Overrides;
+use crate::overrides::{Derive, Overrides};
 
 pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
-    let overrides = Overrides::extract(&input.attrs, true)?;
+    let overrides = Overrides::extract(&input.attrs, true, Derive::Sql)?;
 
     if (overrides.name.is_some() || overrides.rename_all.is_some()) && overrides.transparent {
         return Err(Error::new_spanned(
@@ -98,7 +98,7 @@ pub fn expand_derive_fromsql(input: DeriveInput) -> Result<TokenStream, Error> {
                 let fields = fields
                     .named
                     .iter()
-                    .map(|field| Field::parse(field, overrides.rename_all))
+                    .map(|field| Field::parse(field, overrides.rename_all, Derive::Sql))
                     .collect::<Result<Vec<_>, _>>()?;
                 (
                     accepts::composite_body(&name, "FromSql", &fields),

--- a/postgres-derive/src/lib.rs
+++ b/postgres-derive/src/lib.rs
@@ -1,4 +1,4 @@
-//! An internal crate for `postgres-types`.
+//! Internal derive macros for `postgres-types` and `tokio-postgres`.
 
 #![recursion_limit = "256"]
 extern crate proc_macro;
@@ -10,6 +10,8 @@ mod accepts;
 mod case;
 mod composites;
 mod enums;
+#[cfg(feature = "from-row")]
+mod from_row;
 mod fromsql;
 mod overrides;
 mod tosql;
@@ -28,6 +30,29 @@ pub fn derive_fromsql(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
 
     fromsql::expand_derive_fromsql(input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Derive `tokio_postgres::FromRow` for a struct with named fields.
+///
+/// Fields are decoded from columns with the same name. Use `#[postgres(name = "column")]` on a
+/// field to select another column, or `#[postgres(rename_all = "...")]` on the struct to transform
+/// every field name. Supported rename rules are `lowercase`, `UPPERCASE`, `PascalCase`,
+/// `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`, `SCREAMING-KEBAB-CASE`, and
+/// `Train-Case`. Explicit field names take precedence over `rename_all`. Raw identifiers use their
+/// unprefixed names, so `r#type` maps to `type`.
+///
+/// A container-level `#[postgres(name = "...")]` is accepted but ignored so the struct can also
+/// derive `postgres_types::FromSql` and `postgres_types::ToSql` for a named composite type.
+/// Extra row columns are ignored. Missing columns and values with incompatible types return the
+/// same errors as `Row::try_get`.
+#[cfg(feature = "from-row")]
+#[proc_macro_derive(FromRow, attributes(postgres))]
+pub fn derive_from_row(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input);
+
+    from_row::expand_derive_from_row(input)
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/postgres-derive/src/overrides.rs
+++ b/postgres-derive/src/overrides.rs
@@ -3,6 +3,14 @@ use syn::{Attribute, Error, Expr, ExprLit, Lit, Meta, Token};
 
 use crate::case::{RENAME_RULES, RenameRule};
 
+/// Attribute grammar: row mappings accept names; SQL type derives also accept type options.
+pub enum Derive {
+    Sql,
+    #[cfg(feature = "from-row")]
+    Row,
+}
+
+/// Parsed `#[postgres(...)]` values shared by the derive implementations.
 pub struct Overrides {
     pub name: Option<String>,
     pub rename_all: Option<RenameRule>,
@@ -11,7 +19,11 @@ pub struct Overrides {
 }
 
 impl Overrides {
-    pub fn extract(attrs: &[Attribute], container_attr: bool) -> Result<Overrides, Error> {
+    pub fn extract(
+        attrs: &[Attribute],
+        container_attr: bool,
+        derive: Derive,
+    ) -> Result<Overrides, Error> {
         let mut overrides = Overrides {
             name: None,
             rename_all: None,
@@ -75,7 +87,7 @@ impl Overrides {
                             overrides.rename_all = Some(rename_rule);
                         }
                     }
-                    Meta::Path(path) => {
+                    Meta::Path(path) if matches!(derive, Derive::Sql) => {
                         if path.is_ident("transparent") {
                             if overrides.allow_mismatch {
                                 return Err(Error::new_spanned(

--- a/postgres-derive/src/tosql.rs
+++ b/postgres-derive/src/tosql.rs
@@ -10,10 +10,10 @@ use crate::accepts;
 use crate::composites::Field;
 use crate::composites::{append_generic_bound, new_derive_path};
 use crate::enums::Variant;
-use crate::overrides::Overrides;
+use crate::overrides::{Derive, Overrides};
 
 pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
-    let overrides = Overrides::extract(&input.attrs, true)?;
+    let overrides = Overrides::extract(&input.attrs, true, Derive::Sql)?;
 
     if (overrides.name.is_some() || overrides.rename_all.is_some()) && overrides.transparent {
         return Err(Error::new_spanned(
@@ -92,7 +92,7 @@ pub fn expand_derive_tosql(input: DeriveInput) -> Result<TokenStream, Error> {
                 let fields = fields
                     .named
                     .iter()
-                    .map(|field| Field::parse(field, overrides.rename_all))
+                    .map(|field| Field::parse(field, overrides.rename_all, Derive::Sql))
                     .collect::<Result<Vec<_>, _>>()?;
                 (
                     accepts::composite_body(&name, "ToSql", &fields),

--- a/tokio-postgres/CHANGELOG.md
+++ b/tokio-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+### Added
+
+* Added the `FromRow` trait and feature-gated `#[derive(FromRow)]` support.
+* Added `query_as`, `query_one_as`, and `query_opt_as` to `Client`, `Transaction`, and `GenericClient`.
+
 ## v0.7.18 - 2026-06-12
 
 ### Fixed

--- a/tokio-postgres/Cargo.toml
+++ b/tokio-postgres/Cargo.toml
@@ -24,6 +24,7 @@ all-features = true
 [features]
 default = ["runtime"]
 runtime = ["tokio/net", "tokio/time"]
+derive = ["dep:postgres-derive"]
 
 array-impls = ["postgres-types/array-impls"]
 with-bit-vec-0_6 = ["postgres-types/with-bit-vec-0_6"]
@@ -62,6 +63,7 @@ percent-encoding = "2.0"
 pin-project-lite = "0.2.11"
 phf = "0.13"
 postgres-protocol = { version = "0.6.12", path = "../postgres-protocol" }
+postgres-derive = { version = "0.4.9", optional = true, features = ["from-row"], path = "../postgres-derive" }
 postgres-types = { version = "0.2.14", path = "../postgres-types" }
 tokio = { version = "1.27", features = ["io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -13,8 +13,8 @@ use crate::tls::MakeTlsConnect;
 use crate::tls::TlsConnect;
 use crate::types::{Oid, ToSql, Type};
 use crate::{
-    CancelToken, CopyInSink, Error, Row, SimpleQueryMessage, Statement, ToStatement, Transaction,
-    TransactionBuilder, copy_in, copy_out, prepare, query, simple_query, slice_iter,
+    CancelToken, CopyInSink, Error, FromRow, Row, SimpleQueryMessage, Statement, ToStatement,
+    Transaction, TransactionBuilder, copy_in, copy_out, prepare, query, simple_query, slice_iter,
 };
 use bytes::{Buf, BytesMut};
 use fallible_iterator::FallibleIterator;
@@ -262,6 +262,24 @@ impl Client {
             .await
     }
 
+    /// Execute a query and map its rows with [`FromRow`].
+    ///
+    /// Statement and parameter handling follow [`Client::query`]. Mapping stops at the first error.
+    /// The returned values cannot borrow from the rows; use [`FromRow::from_row`] directly for
+    /// borrowed mappings.
+    pub async fn query_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<R>, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        let rows = self.query(statement, params).await?;
+
+        rows.into_iter().map(|row| R::from_row(&row)).collect()
+    }
+
     /// Returns a vector of scalars.
     pub async fn query_scalar<R: FromSqlOwned, T>(
         &self,
@@ -307,6 +325,24 @@ impl Client {
         self.query_opt(statement, params)
             .await
             .and_then(|res| res.ok_or_else(Error::row_count))
+    }
+
+    /// Execute a query returning exactly one row and map it with [`FromRow`].
+    ///
+    /// Like [`Client::query_one`], this returns an error if the query does not return exactly one
+    /// row. The returned value cannot borrow from the row; use [`FromRow::from_row`] directly for
+    /// borrowed mappings.
+    pub async fn query_one_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<R, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        let row = self.query_one(statement, params).await?;
+
+        R::from_row(&row)
     }
 
     /// Like [`Client::query_one`] but returns one scalar.
@@ -363,6 +399,24 @@ impl Client {
         }
 
         Ok(first)
+    }
+
+    /// Execute a query returning at most one row and map it with [`FromRow`].
+    ///
+    /// Like [`Client::query_opt`], this returns `None` for no rows and an error for more than one.
+    /// The returned value cannot borrow from the row; use [`FromRow::from_row`] directly for
+    /// borrowed mappings.
+    pub async fn query_opt_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<R>, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        let row = self.query_opt(statement, params).await?;
+
+        row.as_ref().map(R::from_row).transpose()
     }
 
     /// Like [`Client::query_opt`] but returns an optional scalar.

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -55,7 +55,7 @@ pub enum SslMode {
 /// TLS negotiation configuration
 ///
 /// See more information at
-/// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION
+/// <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLNEGOTIATION>
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 #[non_exhaustive]
 pub enum SslNegotiation {

--- a/tokio-postgres/src/generic_client.rs
+++ b/tokio-postgres/src/generic_client.rs
@@ -1,6 +1,6 @@
 use crate::query::RowStream;
 use crate::types::{BorrowToSql, ToSql, Type};
-use crate::{Client, Error, Row, SimpleQueryMessage, Statement, ToStatement, Transaction};
+use crate::{Client, Error, FromRow, Row, SimpleQueryMessage, Statement, ToStatement, Transaction};
 use async_trait::async_trait;
 
 mod private {
@@ -37,6 +37,15 @@ pub trait GenericClient: private::Sealed {
     where
         T: ?Sized + ToStatement + Sync + Send;
 
+    /// Like [`Client::query_as`].
+    async fn query_as<R>(
+        &self,
+        query: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<R>, Error>
+    where
+        R: for<'a> FromRow<'a>;
+
     /// Like [`Client::query_one`].
     async fn query_one<T>(
         &self,
@@ -46,6 +55,15 @@ pub trait GenericClient: private::Sealed {
     where
         T: ?Sized + ToStatement + Sync + Send;
 
+    /// Like [`Client::query_one_as`].
+    async fn query_one_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<R, Error>
+    where
+        R: for<'a> FromRow<'a>;
+
     /// Like [`Client::query_opt`].
     async fn query_opt<T>(
         &self,
@@ -54,6 +72,15 @@ pub trait GenericClient: private::Sealed {
     ) -> Result<Option<Row>, Error>
     where
         T: ?Sized + ToStatement + Sync + Send;
+
+    /// Like [`Client::query_opt_as`].
+    async fn query_opt_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<R>, Error>
+    where
+        R: for<'a> FromRow<'a>;
 
     /// Like [`Client::query_raw`].
     async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
@@ -70,14 +97,14 @@ pub trait GenericClient: private::Sealed {
         params: &[(&(dyn ToSql + Sync), Type)],
     ) -> Result<Vec<Row>, Error>;
 
-    /// Like [`Client::query_one_typed`].
+    /// Like [`Client::query_typed_one`].
     async fn query_typed_one(
         &self,
         statement: &str,
         params: &[(&(dyn ToSql + Sync), Type)],
     ) -> Result<Row, Error>;
 
-    /// Like [`Client::query_opt_typed`].
+    /// Like [`Client::query_typed_opt`].
     async fn query_typed_opt(
         &self,
         statement: &str,
@@ -149,6 +176,17 @@ impl GenericClient for Client {
         self.query(query, params).await
     }
 
+    async fn query_as<R>(
+        &self,
+        query: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<R>, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        self.query_as(query, params).await
+    }
+
     async fn query_one<T>(
         &self,
         statement: &T,
@@ -160,6 +198,17 @@ impl GenericClient for Client {
         self.query_one(statement, params).await
     }
 
+    async fn query_one_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<R, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        self.query_one_as(statement, params).await
+    }
+
     async fn query_opt<T>(
         &self,
         statement: &T,
@@ -169,6 +218,17 @@ impl GenericClient for Client {
         T: ?Sized + ToStatement + Sync + Send,
     {
         self.query_opt(statement, params).await
+    }
+
+    async fn query_opt_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<R>, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        self.query_opt_as(statement, params).await
     }
 
     async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
@@ -197,7 +257,7 @@ impl GenericClient for Client {
         self.query_typed_one(statement, params).await
     }
 
-    /// Like [`Client::query_opt_typed`].
+    /// Like [`Client::query_typed_opt`].
     async fn query_typed_opt(
         &self,
         statement: &str,
@@ -272,6 +332,17 @@ impl GenericClient for Transaction<'_> {
         self.query(query, params).await
     }
 
+    async fn query_as<R>(
+        &self,
+        query: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<R>, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        self.query_as(query, params).await
+    }
+
     async fn query_one<T>(
         &self,
         statement: &T,
@@ -283,6 +354,17 @@ impl GenericClient for Transaction<'_> {
         self.query_one(statement, params).await
     }
 
+    async fn query_one_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<R, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        self.query_one_as(statement, params).await
+    }
+
     async fn query_opt<T>(
         &self,
         statement: &T,
@@ -292,6 +374,17 @@ impl GenericClient for Transaction<'_> {
         T: ?Sized + ToStatement + Sync + Send,
     {
         self.query_opt(statement, params).await
+    }
+
+    async fn query_opt_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement + Sync + Send),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<R>, Error>
+    where
+        R: for<'a> FromRow<'a>,
+    {
+        self.query_opt_as(statement, params).await
     }
 
     async fn query_raw<T, P, I>(&self, statement: &T, params: I) -> Result<RowStream, Error>
@@ -320,7 +413,7 @@ impl GenericClient for Transaction<'_> {
         self.query_typed_one(statement, params).await
     }
 
-    /// Like [`Client::query_opt_typed`].
+    /// Like [`Client::query_typed_opt`].
     async fn query_typed_opt(
         &self,
         statement: &str,

--- a/tokio-postgres/src/lib.rs
+++ b/tokio-postgres/src/lib.rs
@@ -34,6 +34,41 @@
 //! }
 //! ```
 //!
+//! # Row Mapping
+//!
+//! The [`FromRow`] trait maps a query row into a Rust type. With the `derive` feature enabled,
+//! structs with named fields can derive an implementation that decodes each field with
+//! [`Row::try_get`]:
+//!
+//! ```no_run
+//! # #[cfg(feature = "derive")]
+//! # async fn run(client: &tokio_postgres::Client) -> Result<(), tokio_postgres::Error> {
+//! use tokio_postgres::FromRow;
+//!
+//! #[derive(FromRow)]
+//! struct User {
+//!     id: i64,
+//!     name: String,
+//! }
+//!
+//! let user = client
+//!     .query_one_as::<User>("SELECT id, name FROM users WHERE id = $1", &[&1i64])
+//!     .await?;
+//! # let _ = (&user.id, &user.name);
+//!
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Derived fields use their Rust identifier as the column name. Override one with
+//! `#[postgres(name = "column")]`, or apply a supported case conversion to every field with
+//! `#[postgres(rename_all = "camelCase")]` on the struct. Explicit field names take precedence.
+//! Extra columns are ignored; missing columns and values with incompatible types return the same
+//! errors as [`Row::try_get`].
+//!
+//! Values returned by `query_as`, `query_one_as`, and `query_opt_as` cannot borrow from the rows.
+//! For borrowed fields, call [`FromRow::from_row`] directly while keeping the row alive.
+//!
 //! # Behavior
 //!
 //! Calling a method like `Client::query` on its own does nothing. The associated request is not sent to the database
@@ -104,6 +139,7 @@
 //! | Feature | Description | Extra dependencies | Default |
 //! | ------- | ----------- | ------------------ | ------- |
 //! | `runtime` | Enable convenience API for the connection process based on the `tokio` crate. | [tokio](https://crates.io/crates/tokio) 1.0 with the features `net` and `time` | yes |
+//! | `derive` | Enable `#[derive(FromRow)]`. | [postgres-derive](https://crates.io/crates/postgres-derive) | no |
 //! | `array-impls` | Enables `ToSql` and `FromSql` trait impls for arrays | - | no |
 //! | `with-bit-vec-0_6` | Enable support for the `bit-vec` crate. | [bit-vec](https://crates.io/crates/bit-vec) 0.6 | no |
 //! | `with-bit-vec-0_7` | Enable support for the `bit-vec` crate. | [bit-vec](https://crates.io/crates/bit-vec) 0.7 | no |
@@ -135,7 +171,7 @@ pub use crate::error::Error;
 pub use crate::generic_client::GenericClient;
 pub use crate::portal::Portal;
 pub use crate::query::RowStream;
-pub use crate::row::{Row, SimpleQueryRow};
+pub use crate::row::{FromRow, Row, SimpleQueryRow};
 pub use crate::simple_query::{SimpleColumn, SimpleQueryStream};
 #[cfg(feature = "runtime")]
 pub use crate::socket::Socket;
@@ -148,6 +184,8 @@ pub use crate::transaction::Transaction;
 pub use crate::transaction_builder::{IsolationLevel, TransactionBuilder};
 use crate::types::ToSql;
 pub use fallible_iterator;
+#[cfg(feature = "derive")]
+pub use postgres_derive::FromRow;
 use std::sync::Arc;
 
 pub mod binary_copy;

--- a/tokio-postgres/src/row.rs
+++ b/tokio-postgres/src/row.rs
@@ -95,6 +95,22 @@ where
     }
 }
 
+/// A type that can be built from a query row.
+///
+/// Implementations typically decode fields with [`Row::try_get`], preserving each column's
+/// [`FromSql`] behavior. The `derive` feature provides an implementation for structs with named
+/// fields through `#[derive(FromRow)]`.
+///
+/// Implementations may borrow from the row. Convenience methods such as
+/// [`Client::query_as`](crate::Client::query_as), [`Client::query_one_as`](crate::Client::query_one_as),
+/// and [`Client::query_opt_as`](crate::Client::query_opt_as) require an implementation for every
+/// row lifetime, so their results cannot borrow from the rows. Call [`FromRow::from_row`] directly
+/// to keep a mapping tied to a live row.
+pub trait FromRow<'a>: Sized {
+    /// Build `Self` from a query row.
+    fn from_row(row: &'a Row) -> Result<Self, Error>;
+}
+
 /// A row of data returned from the database by a query.
 #[derive(Clone)]
 pub struct Row {

--- a/tokio-postgres/src/transaction.rs
+++ b/tokio-postgres/src/transaction.rs
@@ -7,7 +7,7 @@ use crate::tls::MakeTlsConnect;
 use crate::tls::TlsConnect;
 use crate::types::{BorrowToSql, ToSql, Type};
 use crate::{
-    CancelToken, Client, CopyInSink, Error, Portal, Row, SimpleQueryMessage, Statement,
+    CancelToken, Client, CopyInSink, Error, FromRow, Portal, Row, SimpleQueryMessage, Statement,
     ToStatement, bind, query, slice_iter,
 };
 use bytes::Buf;
@@ -100,6 +100,18 @@ impl<'a> Transaction<'a> {
         self.client.query(statement, params).await
     }
 
+    /// Like [`Client::query_as`].
+    pub async fn query_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Vec<R>, Error>
+    where
+        R: for<'row> FromRow<'row>,
+    {
+        self.client.query_as(statement, params).await
+    }
+
     /// Like `Client::query_one`.
     pub async fn query_one<T>(
         &self,
@@ -112,6 +124,18 @@ impl<'a> Transaction<'a> {
         self.client.query_one(statement, params).await
     }
 
+    /// Like [`Client::query_one_as`].
+    pub async fn query_one_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<R, Error>
+    where
+        R: for<'row> FromRow<'row>,
+    {
+        self.client.query_one_as(statement, params).await
+    }
+
     /// Like `Client::query_opt`.
     pub async fn query_opt<T>(
         &self,
@@ -122,6 +146,18 @@ impl<'a> Transaction<'a> {
         T: ?Sized + ToStatement,
     {
         self.client.query_opt(statement, params).await
+    }
+
+    /// Like [`Client::query_opt_as`].
+    pub async fn query_opt_as<R>(
+        &self,
+        statement: &(impl ?Sized + ToStatement),
+        params: &[&(dyn ToSql + Sync)],
+    ) -> Result<Option<R>, Error>
+    where
+        R: for<'row> FromRow<'row>,
+    {
+        self.client.query_opt_as(statement, params).await
     }
 
     /// Like `Client::query_raw`.

--- a/tokio-postgres/tests/test/from_row.rs
+++ b/tokio-postgres/tests/test/from_row.rs
@@ -1,0 +1,363 @@
+use super::connect;
+use tokio_postgres::error::SqlState;
+use tokio_postgres::{Error, FromRow, GenericClient, Row};
+
+#[derive(Debug, PartialEq)]
+struct User {
+    id: i32,
+    name: String,
+}
+
+impl<'a> FromRow<'a> for User {
+    fn from_row(row: &'a Row) -> Result<Self, Error> {
+        let id = row.try_get("id")?;
+        let name = row.try_get("name")?;
+
+        Ok(User { id, name })
+    }
+}
+
+async fn query_user<C>(client: &C, id: i32) -> Result<User, Error>
+where
+    C: GenericClient,
+{
+    client
+        .query_one_as(
+            "SELECT $1::INT AS id, ('user-' || ($1::INT)::TEXT) AS name",
+            &[&id],
+        )
+        .await
+}
+
+#[cfg(feature = "derive")]
+#[tokio::test]
+async fn derives_borrowed_fields_from_a_live_row() {
+    #[derive(Debug, FromRow, PartialEq)]
+    struct Borrowed<'a> {
+        label: &'a str,
+        payload: &'a [u8],
+    }
+
+    let client = connect("user=postgres").await;
+    let row = client
+        .query_one(
+            "SELECT 'borrowed'::TEXT AS label, decode('000102ff', 'hex') AS payload",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    let value = Borrowed::from_row(&row).unwrap();
+
+    assert_eq!(
+        value,
+        Borrowed {
+            label: "borrowed",
+            payload: &[0, 1, 2, 255],
+        }
+    );
+}
+
+#[tokio::test]
+async fn client_maps_rows_and_preserves_query_errors() {
+    const ONE: &str = "SELECT 1::INT AS id, 'alice'::TEXT AS name";
+    const NONE: &str = "SELECT 1::INT AS id, 'alice'::TEXT AS name WHERE FALSE";
+    const MANY: &str = "SELECT id, name FROM (VALUES (1::INT, 'alice'::TEXT), (2, 'bob')) AS users(id, name) ORDER BY id";
+    const MISSING_COLUMN: &str = "SELECT 1::INT AS id";
+    const WRONG_TYPE: &str = "SELECT 'not an integer'::TEXT AS id, 'alice'::TEXT AS name";
+
+    let client = connect("user=postgres").await;
+
+    let users = client.query_as::<User>(MANY, &[]).await.unwrap();
+    assert_eq!(
+        users,
+        vec![
+            User {
+                id: 1,
+                name: "alice".to_string(),
+            },
+            User {
+                id: 2,
+                name: "bob".to_string(),
+            },
+        ]
+    );
+
+    let statement = client.prepare(ONE).await.unwrap();
+    let user = client.query_one_as::<User>(&statement, &[]).await.unwrap();
+    assert_eq!(
+        user,
+        User {
+            id: 1,
+            name: "alice".to_string(),
+        }
+    );
+
+    let user = client.query_opt_as::<User>(ONE, &[]).await.unwrap();
+    assert_eq!(
+        user,
+        Some(User {
+            id: 1,
+            name: "alice".to_string(),
+        })
+    );
+    let user = client.query_opt_as::<User>(NONE, &[]).await.unwrap();
+    assert_eq!(user, None);
+    let users = client.query_as::<User>(NONE, &[]).await.unwrap();
+    assert!(users.is_empty());
+
+    let error = client.query_one_as::<User>(NONE, &[]).await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "query returned an unexpected number of rows"
+    );
+    let error = client.query_one_as::<User>(MANY, &[]).await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "query returned an unexpected number of rows"
+    );
+    let error = client.query_opt_as::<User>(MANY, &[]).await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "query returned an unexpected number of rows"
+    );
+
+    let error = client.query_as::<User>(WRONG_TYPE, &[]).await.unwrap_err();
+    assert_eq!(error.to_string(), "error deserializing column 0");
+    let error = client
+        .query_one_as::<User>(WRONG_TYPE, &[])
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "error deserializing column 0");
+    let error = client
+        .query_opt_as::<User>(WRONG_TYPE, &[])
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "error deserializing column 0");
+
+    let error = client
+        .query_one_as::<User>(MISSING_COLUMN, &[])
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "invalid column `name`");
+
+    let error = client
+        .query_one_as::<User>("SELECT 1 / 0 AS id", &[])
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Some(&SqlState::DIVISION_BY_ZERO));
+}
+
+#[tokio::test]
+async fn mapping_stops_at_errors_and_follows_row_count_checks() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static MAPPINGS: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug)]
+    struct Mapped;
+
+    impl<'a> FromRow<'a> for Mapped {
+        fn from_row(row: &'a Row) -> Result<Self, Error> {
+            MAPPINGS.fetch_add(1, Ordering::Relaxed);
+            let _: i32 = row.try_get(0)?;
+
+            Ok(Mapped)
+        }
+    }
+
+    const QUERY: &str = "SELECT value FROM (VALUES (1, 1), (2, NULL), (3, 3)) AS rows(position, value) ORDER BY position";
+    let client = connect("user=postgres").await;
+
+    let error = client.query_as::<Mapped>(QUERY, &[]).await.unwrap_err();
+    assert_eq!(error.to_string(), "error deserializing column 0");
+    let mappings = MAPPINGS.load(Ordering::Relaxed);
+    assert_eq!(mappings, 2);
+
+    MAPPINGS.store(0, Ordering::Relaxed);
+    let error = client.query_one_as::<Mapped>(QUERY, &[]).await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "query returned an unexpected number of rows"
+    );
+    let error = client.query_opt_as::<Mapped>(QUERY, &[]).await.unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "query returned an unexpected number of rows"
+    );
+    let mappings = MAPPINGS.load(Ordering::Relaxed);
+    assert_eq!(mappings, 0);
+}
+
+#[tokio::test]
+async fn transaction_and_generic_client_map_rows() {
+    let mut client = connect("user=postgres").await;
+
+    let user = query_user(&client, 3).await.unwrap();
+    assert_eq!(
+        user,
+        User {
+            id: 3,
+            name: "user-3".to_string(),
+        }
+    );
+
+    let transaction = client.transaction().await.unwrap();
+    let users = transaction
+        .query_as::<User>(
+            "SELECT id, ('user-' || id::TEXT) AS name FROM generate_series(4, 5) AS users(id) ORDER BY id",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        users,
+        vec![
+            User {
+                id: 4,
+                name: "user-4".to_string(),
+            },
+            User {
+                id: 5,
+                name: "user-5".to_string(),
+            },
+        ]
+    );
+
+    let user = transaction
+        .query_one_as::<User>("SELECT 6::INT AS id, 'user-6'::TEXT AS name", &[])
+        .await
+        .unwrap();
+    assert_eq!(
+        user,
+        User {
+            id: 6,
+            name: "user-6".to_string(),
+        }
+    );
+
+    let user = transaction
+        .query_opt_as::<User>(
+            "SELECT 7::INT AS id, 'user-7'::TEXT AS name WHERE FALSE",
+            &[],
+        )
+        .await
+        .unwrap();
+    assert_eq!(user, None);
+
+    let user = query_user(&transaction, 8).await.unwrap();
+    assert_eq!(
+        user,
+        User {
+            id: 8,
+            name: "user-8".to_string(),
+        }
+    );
+
+    transaction.rollback().await.unwrap();
+}
+
+#[cfg(feature = "derive")]
+#[tokio::test]
+async fn derives_named_fields_and_preserves_column_decoding() {
+    #[derive(Debug, FromRow, PartialEq)]
+    #[postgres(rename_all = "camelCase")]
+    struct UnusualNames {
+        #[postgres(name = "display-name")]
+        display_name: String,
+        r#type: String,
+        nick_name: Option<String>,
+    }
+
+    let client = connect("user=postgres").await;
+
+    let value = client
+        .query_one_as::<UnusualNames>(
+            "SELECT 'shown'::TEXT AS \"display-name\", 'kind'::TEXT AS \"type\", NULL::TEXT AS \"nickName\", true AS extra",
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        value,
+        UnusualNames {
+            display_name: "shown".to_string(),
+            r#type: "kind".to_string(),
+            nick_name: None,
+        }
+    );
+
+    let error = client
+        .query_one_as::<UnusualNames>(
+            "SELECT 1::INT AS \"display-name\", 'kind'::TEXT AS \"type\", NULL::TEXT AS \"nickName\"",
+            &[],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "error deserializing column 0");
+
+    let error = client
+        .query_one_as::<UnusualNames>(
+            "SELECT 'shown'::TEXT AS \"display-name\", 'kind'::TEXT AS \"type\"",
+            &[],
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(error.to_string(), "invalid column `nickName`");
+}
+
+#[cfg(feature = "derive")]
+#[tokio::test]
+async fn honors_every_rename_all_rule() {
+    macro_rules! rename_case {
+        ($name:ident, $rule:literal) => {
+            #[allow(non_snake_case)]
+            #[derive(FromRow)]
+            #[postgres(rename_all = $rule)]
+            struct $name {
+                sampleField: i32,
+            }
+        };
+    }
+
+    rename_case!(Lowercase, "lowercase");
+    rename_case!(Uppercase, "UPPERCASE");
+    rename_case!(PascalCase, "PascalCase");
+    rename_case!(CamelCase, "camelCase");
+    rename_case!(SnakeCase, "snake_case");
+    rename_case!(ScreamingSnakeCase, "SCREAMING_SNAKE_CASE");
+    rename_case!(KebabCase, "kebab-case");
+    rename_case!(ScreamingKebabCase, "SCREAMING-KEBAB-CASE");
+    rename_case!(TrainCase, "Train-Case");
+
+    let client = connect("user=postgres").await;
+    let row = client
+        .query_one(
+            r#"
+                SELECT
+                    1::INT AS "samplefield",
+                    2::INT AS "SAMPLEFIELD",
+                    3::INT AS "SampleField",
+                    4::INT AS "sampleField",
+                    5::INT AS "sample_field",
+                    6::INT AS "SAMPLE_FIELD",
+                    7::INT AS "sample-field",
+                    8::INT AS "SAMPLE-FIELD",
+                    9::INT AS "Sample-Field"
+            "#,
+            &[],
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(Lowercase::from_row(&row).unwrap().sampleField, 1);
+    assert_eq!(Uppercase::from_row(&row).unwrap().sampleField, 2);
+    assert_eq!(PascalCase::from_row(&row).unwrap().sampleField, 3);
+    assert_eq!(CamelCase::from_row(&row).unwrap().sampleField, 4);
+    assert_eq!(SnakeCase::from_row(&row).unwrap().sampleField, 5);
+    assert_eq!(ScreamingSnakeCase::from_row(&row).unwrap().sampleField, 6);
+    assert_eq!(KebabCase::from_row(&row).unwrap().sampleField, 7);
+    assert_eq!(ScreamingKebabCase::from_row(&row).unwrap().sampleField, 8);
+    assert_eq!(TrainCase::from_row(&row).unwrap().sampleField, 9);
+}

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -19,6 +19,7 @@ use tokio_postgres::{
 };
 
 mod binary_copy;
+mod from_row;
 mod parse;
 #[cfg(feature = "runtime")]
 mod runtime;

--- a/tokio-postgres/tests/test/types/mod.rs
+++ b/tokio-postgres/tests/test/types/mod.rs
@@ -48,7 +48,7 @@ mod uuid_1;
 
 async fn test_type<T, S>(sql_type: &str, checks: &[(T, S)])
 where
-    T: PartialEq + for<'a> FromSqlOwned + ToSql + Sync,
+    T: PartialEq + FromSqlOwned + ToSql + Sync,
     S: fmt::Display,
 {
     let client = connect("user=postgres").await;


### PR DESCRIPTION
`FromRow` maps query rows into Rust structs. With the `derive` feature enabled, the generated implementation uses `Row::try_get` and existing `FromSql` decoding:

```rust
use tokio_postgres::FromRow;

#[derive(FromRow)]
struct User {
    id: i64,
    name: String,
}

let users = client
    .query_as::<User>("SELECT id, name FROM users ORDER BY id", &[])
    .await?;
```

`query_as`, `query_one_as`, and `query_opt_as` are available on `Client`, `Transaction`, and `GenericClient`. Their results cannot borrow from the rows; direct `FromRow::from_row(&row)` conversion supports borrowed fields.
