### PR TITLE
feat: expose type OID and modifier on SimpleColumn

### DIFF
--- a/tokio-postgres/src/simple_query.rs
+++ b/tokio-postgres/src/simple_query.rs
@@ -10,6 +10,7 @@ use log::debug;
 use pin_project_lite::pin_project;
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
+use postgres_types::Oid;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, ready};
@@ -18,16 +19,32 @@ use std::task::{Context, Poll, ready};
 #[derive(Debug)]
 pub struct SimpleColumn {
     name: String,
+    type_oid: Oid,
+    type_modifier: i32,
 }
 
 impl SimpleColumn {
-    pub(crate) fn new(name: String) -> SimpleColumn {
-        SimpleColumn { name }
+    pub(crate) fn new(name: String, type_oid: Oid, type_modifier: i32) -> SimpleColumn {
+        SimpleColumn {
+            name,
+            type_oid,
+            type_modifier,
+        }
     }
 
     /// Returns the name of the column.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Returns the OID of the column type.
+    pub fn type_oid(&self) -> Oid {
+        self.type_oid
+    }
+
+    /// Returns the modifier of the column type.
+    pub fn type_modifier(&self) -> i32 {
+        self.type_modifier
     }
 }
 
@@ -93,7 +110,13 @@ impl Stream for SimpleQueryStream {
             Message::RowDescription(body) => {
                 let columns: Arc<[SimpleColumn]> = body
                     .fields()
-                    .map(|f| Ok(SimpleColumn::new(f.name().to_string())))
+                    .map(|f| {
+                        Ok(SimpleColumn::new(
+                            f.name().to_string(),
+                            f.type_oid(),
+                            f.type_modifier(),
+                        ))
+                    })
                     .collect::<Vec<_>>()
                     .map_err(Error::parse)?
                     .into();

--- a/tokio-postgres/tests/test/main.rs
+++ b/tokio-postgres/tests/test/main.rs
@@ -340,9 +340,10 @@ async fn simple_query() {
         .simple_query(
             "CREATE TEMPORARY TABLE foo (
                 id SERIAL,
-                name TEXT
+                name TEXT,
+                description VARCHAR(50)
             );
-            INSERT INTO foo (name) VALUES ('steven'), ('joe');
+            INSERT INTO foo (name, description) VALUES ('steven', 'a'), ('joe', 'b');
             SELECT * FROM foo ORDER BY id;",
         )
         .await
@@ -358,26 +359,76 @@ async fn simple_query() {
     }
     match &messages[2] {
         SimpleQueryMessage::RowDescription(columns) => {
-            assert_eq!(columns.get(0).map(|c| c.name()), Some("id"));
-            assert_eq!(columns.get(1).map(|c| c.name()), Some("name"));
+            assert_eq!(
+                columns
+                    .get(0)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("id", Type::INT4.oid(), -1))
+            );
+            assert_eq!(
+                columns
+                    .get(1)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("name", Type::TEXT.oid(), -1))
+            );
+            assert_eq!(
+                columns
+                    .get(2)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("description", Type::VARCHAR.oid(), 54))
+            );
         }
         _ => panic!("unexpected message"),
     }
     match &messages[3] {
         SimpleQueryMessage::Row(row) => {
-            assert_eq!(row.columns().get(0).map(|c| c.name()), Some("id"));
-            assert_eq!(row.columns().get(1).map(|c| c.name()), Some("name"));
+            assert_eq!(
+                row.columns()
+                    .get(0)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("id", Type::INT4.oid(), -1))
+            );
+            assert_eq!(
+                row.columns()
+                    .get(1)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("name", Type::TEXT.oid(), -1))
+            );
+            assert_eq!(
+                row.columns()
+                    .get(2)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("description", Type::VARCHAR.oid(), 54))
+            );
             assert_eq!(row.get(0), Some("1"));
             assert_eq!(row.get(1), Some("steven"));
+            assert_eq!(row.get(2), Some("a"));
         }
         _ => panic!("unexpected message"),
     }
     match &messages[4] {
         SimpleQueryMessage::Row(row) => {
-            assert_eq!(row.columns().get(0).map(|c| c.name()), Some("id"));
-            assert_eq!(row.columns().get(1).map(|c| c.name()), Some("name"));
+            assert_eq!(
+                row.columns()
+                    .get(0)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("id", Type::INT4.oid(), -1))
+            );
+            assert_eq!(
+                row.columns()
+                    .get(1)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("name", Type::TEXT.oid(), -1))
+            );
+            assert_eq!(
+                row.columns()
+                    .get(2)
+                    .map(|c| (c.name(), c.type_oid(), c.type_modifier())),
+                Some(("description", Type::VARCHAR.oid(), 54))
+            );
             assert_eq!(row.get(0), Some("2"));
             assert_eq!(row.get(1), Some("joe"));
+            assert_eq!(row.get(2), Some("b"));
         }
         _ => panic!("unexpected message"),
     }


### PR DESCRIPTION
The simple query protocol's RowDescription message carries the type OID and type modifier for each column, but SimpleColumn was dropping both. Clients rendering column types (e.g. distinguishing varchar(50) from text) need access to this metadata, matching what's already exposed on Column for the extended query protocol.

Closes: https://github.com/rust-postgres/rust-postgres/issues/1329