### PR TITLE
Fix memory retention issue in BytesMut and add unit tests

### DIFF
--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -41,7 +41,6 @@ use tokio::io::{AsyncRead, AsyncWrite};
 pub struct Responses {
     receiver: mpsc::Receiver<BackendMessages>,
     cur: BackendMessages,
-    buffer_size: usize,
 }
 
 impl Responses {
@@ -50,13 +49,7 @@ impl Responses {
             match self.cur.next().map_err(Error::parse)? {
                 Some(Message::ErrorResponse(body)) => return Poll::Ready(Err(Error::db(body))),
                 Some(message) => return Poll::Ready(Ok(message)),
-                None => {
-                    if self.cur.capacity() > self.buffer_size {
-                        // Drop the drained batch before waiting for the next one so
-                        // large response buffers are not retained longer than needed.
-                        self.cur = BackendMessages::with_capacity(self.buffer_size);
-                    }
-                }
+                None => {}
             }
 
             match ready!(self.receiver.poll_next_unpin(cx)) {
@@ -110,8 +103,9 @@ impl InnerClient {
 
         Ok(Responses {
             receiver,
-            cur: BackendMessages::with_capacity(self.buffer_size),
-            buffer_size: self.buffer_size,
+            // The first batch from the channel replaces `cur`, so there is no
+            // need to pre-allocate here.
+            cur: BackendMessages::with_capacity(0),
         })
     }
 
@@ -816,25 +810,6 @@ impl fmt::Debug for Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::task::noop_waker_ref;
-
-    #[test]
-    fn responses_drop_oversized_drained_batch_before_waiting() {
-        let buffer_size = 16;
-        let (_sender, receiver) = mpsc::channel(1);
-        let mut responses = Responses {
-            receiver,
-            cur: BackendMessages::with_capacity(1024 * 1024),
-            buffer_size,
-        };
-
-        let waker = noop_waker_ref();
-        let mut cx = Context::from_waker(waker);
-
-        assert!(responses.cur.capacity() > buffer_size);
-        assert!(matches!(responses.poll_next(&mut cx), Poll::Pending));
-        assert!(responses.cur.capacity() <= buffer_size);
-    }
 
     #[test]
     fn inner_client_drops_oversized_write_buffer_after_use() {

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -812,3 +812,45 @@ impl fmt::Debug for Client {
         f.debug_struct("Client").finish()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::task::noop_waker_ref;
+
+    #[test]
+    fn responses_drop_oversized_drained_batch_before_waiting() {
+        let buffer_size = 16;
+        let (_sender, receiver) = mpsc::channel(1);
+        let mut responses = Responses {
+            receiver,
+            cur: BackendMessages::with_capacity(1024 * 1024),
+            buffer_size,
+        };
+
+        let waker = noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+
+        assert!(responses.cur.capacity() > buffer_size);
+        assert!(matches!(responses.poll_next(&mut cx), Poll::Pending));
+        assert!(responses.cur.capacity() <= buffer_size);
+    }
+
+    #[test]
+    fn inner_client_drops_oversized_write_buffer_after_use() {
+        let buffer_size = 16;
+        let (sender, _receiver) = mpsc::unbounded();
+        let client = InnerClient {
+            sender,
+            cached_typeinfo: Default::default(),
+            buffer_size,
+            buffer: Mutex::new(BytesMut::with_capacity(buffer_size)),
+        };
+
+        client.with_buf(|buf| {
+            buf.reserve(1024 * 1024);
+        });
+
+        assert!(client.buffer.lock().capacity() <= buffer_size);
+    }
+}

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -286,11 +286,9 @@ impl Client {
             .try_collect()
             .await?;
 
-        if let Some(row) = rows.first() {
-            if row.len() != 1 {
-                return Err(Error::column_count());
-            }
-        };
+        if matches!(rows.first(), Some(row) if row.len() != 1) {
+            return Err(Error::column_count());
+        }
 
         rows.into_iter().map(|r| r.try_get(0)).collect()
     }
@@ -385,10 +383,8 @@ impl Client {
     {
         let row = self.query_opt(statement, params).await?;
 
-        if let Some(row) = &row {
-            if row.len() != 1 {
-                return Err(Error::column_count());
-            }
+        if matches!(row.as_ref(), Some(row) if row.len() != 1) {
+            return Err(Error::column_count());
         }
 
         row.map(|x| x.try_get::<_, R>(0)).transpose()

--- a/tokio-postgres/src/client.rs
+++ b/tokio-postgres/src/client.rs
@@ -41,6 +41,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 pub struct Responses {
     receiver: mpsc::Receiver<BackendMessages>,
     cur: BackendMessages,
+    buffer_size: usize,
 }
 
 impl Responses {
@@ -49,7 +50,13 @@ impl Responses {
             match self.cur.next().map_err(Error::parse)? {
                 Some(Message::ErrorResponse(body)) => return Poll::Ready(Err(Error::db(body))),
                 Some(message) => return Poll::Ready(Ok(message)),
-                None => {}
+                None => {
+                    if self.cur.capacity() > self.buffer_size {
+                        // Drop the drained batch before waiting for the next one so
+                        // large response buffers are not retained longer than needed.
+                        self.cur = BackendMessages::with_capacity(self.buffer_size);
+                    }
+                }
             }
 
             match ready!(self.receiver.poll_next_unpin(cx)) {
@@ -87,6 +94,7 @@ struct CachedTypeInfo {
 pub struct InnerClient {
     sender: mpsc::UnboundedSender<Request>,
     cached_typeinfo: Mutex<CachedTypeInfo>,
+    buffer_size: usize,
 
     /// A buffer to use when writing out postgres commands.
     buffer: Mutex<BytesMut>,
@@ -102,7 +110,8 @@ impl InnerClient {
 
         Ok(Responses {
             receiver,
-            cur: BackendMessages::empty(),
+            cur: BackendMessages::with_capacity(self.buffer_size),
+            buffer_size: self.buffer_size,
         })
     }
 
@@ -150,7 +159,11 @@ impl InnerClient {
     {
         let mut buffer = self.buffer.lock();
         let r = f(&mut buffer);
-        buffer.clear();
+        if buffer.capacity() > self.buffer_size {
+            *buffer = BytesMut::with_capacity(self.buffer_size);
+        } else {
+            buffer.clear();
+        }
         r
     }
 }
@@ -195,12 +208,14 @@ impl Client {
         ssl_negotiation: SslNegotiation,
         process_id: i32,
         secret_key: i32,
+        buffer_size: usize,
     ) -> Client {
         Client {
             inner: Arc::new(InnerClient {
                 sender,
                 cached_typeinfo: Default::default(),
-                buffer: Default::default(),
+                buffer_size,
+                buffer: Mutex::new(BytesMut::with_capacity(buffer_size)),
             }),
             #[cfg(feature = "runtime")]
             socket_config: None,

--- a/tokio-postgres/src/codec.rs
+++ b/tokio-postgres/src/codec.rs
@@ -21,8 +21,16 @@ pub enum BackendMessage {
 pub struct BackendMessages(BytesMut);
 
 impl BackendMessages {
-    pub fn empty() -> BackendMessages {
-        BackendMessages(BytesMut::new())
+    pub fn with_capacity(capacity: usize) -> BackendMessages {
+        BackendMessages(BytesMut::with_capacity(capacity))
+    }
+
+    fn with_buffer(buffer: BytesMut) -> BackendMessages {
+        BackendMessages(buffer)
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
     }
 }
 
@@ -90,7 +98,7 @@ impl Decoder for PostgresCodec {
             Ok(None)
         } else {
             Ok(Some(BackendMessage::Normal {
-                messages: BackendMessages(src.split_to(idx)),
+                messages: BackendMessages::with_buffer(src.split_to(idx)),
                 request_complete,
             }))
         }

--- a/tokio-postgres/src/codec.rs
+++ b/tokio-postgres/src/codec.rs
@@ -28,10 +28,6 @@ impl BackendMessages {
     fn with_buffer(buffer: BytesMut) -> BackendMessages {
         BackendMessages(buffer)
     }
-
-    pub fn capacity(&self) -> usize {
-        self.0.capacity()
-    }
 }
 
 impl FallibleIterator for BackendMessages {
@@ -43,7 +39,23 @@ impl FallibleIterator for BackendMessages {
     }
 }
 
-pub struct PostgresCodec;
+pub struct PostgresCodec {
+    /// Upper bound (in bytes) the `Framed` read buffer is reclaimed back down
+    /// to once a completed batch drains it, instead of pinning grown capacity.
+    max_buffer_size: usize,
+}
+
+impl PostgresCodec {
+    pub fn new(max_buffer_size: usize) -> PostgresCodec {
+        PostgresCodec { max_buffer_size }
+    }
+
+    /// Upper bound (in bytes) the codec's `Framed` buffers should be reclaimed
+    /// back down to once a connection goes idle.
+    pub fn max_buffer_size(&self) -> usize {
+        self.max_buffer_size
+    }
+}
 
 impl Encoder<FrontendMessage> for PostgresCodec {
     type Error = io::Error;
@@ -97,10 +109,156 @@ impl Decoder for PostgresCodec {
         if idx == 0 {
             Ok(None)
         } else {
+            let messages = BackendMessages::with_buffer(src.split_to(idx));
+
+            // `Framed` keeps `src` grown to the largest batch ever read, pinning
+            // multi-MB capacity for a pooled connection's lifetime. Once the
+            // remaining tail fits the bound, move it into a freshly bounded
+            // buffer. A single in-flight message larger than the bound is left
+            // untouched so its bytes stay contiguous.
+            if src.capacity() > self.max_buffer_size && src.len() <= self.max_buffer_size {
+                let mut bounded = BytesMut::with_capacity(self.max_buffer_size);
+                bounded.extend_from_slice(src);
+                *src = bounded;
+            }
+
             Ok(Some(BackendMessage::Normal {
-                messages: BackendMessages::with_buffer(src.split_to(idx)),
+                messages,
                 request_complete,
             }))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::BufMut;
+    use postgres_protocol::message::backend;
+
+    /// Append a single backend protocol frame: tag, big-endian length (which
+    /// includes the 4-byte length field but not the tag), then the body.
+    fn push_frame(buf: &mut BytesMut, tag: u8, body: &[u8]) {
+        buf.put_u8(tag);
+        buf.put_i32((body.len() + 4) as i32);
+        buf.put_slice(body);
+    }
+
+    /// A completed batch that fully drains an oversized read buffer must be
+    /// reclaimed back down to the configured bound.
+    #[test]
+    fn decode_reclaims_oversized_drained_buffer() {
+        let bound = 256;
+        let mut codec = PostgresCodec::new(bound);
+
+        let mut src = BytesMut::with_capacity(1024 * 1024);
+        push_frame(&mut src, backend::COMMAND_COMPLETE_TAG, b"INSERT 0 1\0");
+        push_frame(&mut src, backend::READY_FOR_QUERY_TAG, b"I");
+
+        assert!(src.capacity() > bound);
+        let message = codec.decode(&mut src).unwrap();
+        assert!(matches!(
+            message,
+            Some(BackendMessage::Normal {
+                request_complete: true,
+                ..
+            })
+        ));
+        // Buffer was fully drained, so it should be reclaimed to the bound.
+        assert!(src.is_empty());
+        assert!(src.capacity() <= bound);
+    }
+
+    /// A buffer that stays under the bound is left untouched (no realloc churn).
+    #[test]
+    fn decode_keeps_small_buffer() {
+        let bound = 1024 * 1024;
+        let mut codec = PostgresCodec::new(bound);
+
+        let mut src = BytesMut::with_capacity(256);
+        push_frame(&mut src, backend::COMMAND_COMPLETE_TAG, b"SELECT 1\0");
+        push_frame(&mut src, backend::READY_FOR_QUERY_TAG, b"I");
+        let capacity_before = src.capacity();
+
+        let _ = codec.decode(&mut src).unwrap();
+
+        // Under the bound: capacity is not forcibly reallocated upward.
+        assert!(src.capacity() <= capacity_before.max(bound));
+    }
+
+    /// When a partial trailing message remains, its bytes must survive while
+    /// the oversized backing buffer is still reclaimed (the tail is copied
+    /// forward, not dropped).
+    #[test]
+    fn decode_preserves_partial_trailing_message() {
+        let bound = 64;
+        let mut codec = PostgresCodec::new(bound);
+
+        let mut src = BytesMut::with_capacity(1024 * 1024);
+        push_frame(&mut src, backend::COMMAND_COMPLETE_TAG, b"INSERT 0 1\0");
+        push_frame(&mut src, backend::READY_FOR_QUERY_TAG, b"I");
+        // A trailing frame header that promises 100 body bytes but supplies none.
+        src.put_u8(backend::DATA_ROW_TAG);
+        src.put_i32(104);
+
+        let _ = codec.decode(&mut src).unwrap();
+
+        // `ReadyForQuery` ends the batch before the trailing frame, so its
+        // header bytes must survive...
+        assert!(!src.is_empty());
+        // ...exactly the 5-byte trailing header remains...
+        assert_eq!(src.len(), 5);
+        // ...and because that tail fits the bound, the oversized backing is
+        // reclaimed rather than retained.
+        assert!(src.capacity() <= bound);
+    }
+
+    /// Simulates the bounce-back: a small amount of new data sitting in a
+    /// reclaimed oversized backing (capacity well past the bound) must be
+    /// reclaimed on the next decode, preserving the in-flight bytes.
+    #[test]
+    fn decode_reclaims_oversized_backing_with_small_tail() {
+        let bound = 64;
+        let mut codec = PostgresCodec::new(bound);
+
+        // Oversized backing holding a complete frame plus a small partial tail.
+        let mut src = BytesMut::with_capacity(1024 * 1024);
+        push_frame(&mut src, backend::COMMAND_COMPLETE_TAG, b"INSERT 0 1\0");
+        // Partial trailing header (5 bytes) — no ReadyForQuery this time.
+        src.put_u8(backend::DATA_ROW_TAG);
+        src.put_i32(104);
+
+        assert!(src.capacity() > bound);
+        let _ = codec.decode(&mut src).unwrap();
+
+        // The complete frame was consumed; the 5-byte partial tail survives and
+        // the buffer is reclaimed to the bound.
+        assert_eq!(src.len(), 5);
+        assert!(src.capacity() <= bound);
+    }
+
+    /// A single in-flight message larger than the bound must not be reclaimed —
+    /// its bytes have to stay contiguous, so the buffer may exceed the bound
+    /// for exactly that case.
+    #[test]
+    fn decode_keeps_oversized_single_message() {
+        let bound = 64;
+        let mut codec = PostgresCodec::new(bound);
+
+        let mut src = BytesMut::with_capacity(1024 * 1024);
+        // A complete small frame to consume, then a large partial frame that
+        // alone exceeds the bound and is still arriving.
+        push_frame(&mut src, backend::COMMAND_COMPLETE_TAG, b"INSERT 0 1\0");
+        src.put_u8(backend::DATA_ROW_TAG);
+        src.put_i32(2004); // promises 2000 body bytes...
+        src.put_slice(&[0u8; 200]); // ...but only 200 have arrived so far.
+
+        let len_before = src.len();
+        let _ = codec.decode(&mut src).unwrap();
+
+        // The partial large message (> bound) remains intact and is not
+        // truncated or reclaimed.
+        assert!(src.len() > bound);
+        assert!(src.len() < len_before);
     }
 }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -100,6 +100,8 @@ pub enum Host {
     Unix(PathBuf),
 }
 
+const DEFAULT_BUFFER_SIZE: usize = 8 * 1024;
+
 /// Connection configuration.
 ///
 /// Configuration can be parsed from libpq-style connection strings. These strings come in two formats:
@@ -149,6 +151,7 @@ pub enum Host {
 ///     omitted or the empty string.
 /// * `connect_timeout` - The time limit in seconds applied to each socket-level connection attempt. Note that hostnames
 ///     can resolve to multiple IP addresses, and this limit is applied to each address. Defaults to no timeout.
+/// * `buffer_size` - The initial capacity, in bytes, of the connection's buffers. Defaults to 8192.
 /// * `tcp_user_timeout` - The time limit that transmitted data may remain unacknowledged before a connection is forcibly closed.
 ///     This is ignored for Unix domain socket connections. It is only supported on systems where TCP_USER_TIMEOUT is available
 ///     and will default to the system default if omitted or set to 0; on other systems, it has no effect.
@@ -228,6 +231,7 @@ pub struct Config {
     pub(crate) hostaddr: Vec<IpAddr>,
     pub(crate) port: Vec<u16>,
     pub(crate) connect_timeout: Option<Duration>,
+    pub(crate) buffer_size: usize,
     pub(crate) tcp_user_timeout: Option<Duration>,
     pub(crate) keepalives: bool,
     #[cfg(not(target_arch = "wasm32"))]
@@ -258,6 +262,7 @@ impl Config {
             hostaddr: vec![],
             port: vec![],
             connect_timeout: None,
+            buffer_size: DEFAULT_BUFFER_SIZE,
             tcp_user_timeout: None,
             keepalives: true,
             #[cfg(not(target_arch = "wasm32"))]
@@ -443,6 +448,19 @@ impl Config {
     /// `connect_timeout` method.
     pub fn get_connect_timeout(&self) -> Option<&Duration> {
         self.connect_timeout.as_ref()
+    }
+
+    /// Sets the initial capacity of the connection's buffers.
+    ///
+    /// Defaults to 8192 bytes.
+    pub fn buffer_size(&mut self, buffer_size: usize) -> &mut Config {
+        self.buffer_size = buffer_size;
+        self
+    }
+
+    /// Gets the configured initial buffer capacity.
+    pub fn get_buffer_size(&self) -> usize {
+        self.buffer_size
     }
 
     /// Sets the TCP user timeout.
@@ -634,6 +652,15 @@ impl Config {
                     self.connect_timeout(Duration::from_secs(timeout as u64));
                 }
             }
+            "buffer_size" => {
+                let buffer_size = value
+                    .parse::<usize>()
+                    .map_err(|_| Error::config_parse(Box::new(InvalidValue("buffer_size"))))?;
+                if buffer_size == 0 {
+                    return Err(Error::config_parse(Box::new(InvalidValue("buffer_size"))));
+                }
+                self.buffer_size(buffer_size);
+            }
             "tcp_user_timeout" => {
                 let timeout = value
                     .parse::<i64>()
@@ -735,7 +762,8 @@ impl Config {
 
     /// Connects to a PostgreSQL database over an arbitrary stream.
     ///
-    /// All of the settings other than `user`, `password`, `dbname`, `options`, and `application_name` name are ignored.
+    /// All of the settings other than `user`, `password`, `dbname`, `options`, `application_name`, and
+    /// `buffer_size` are ignored.
     pub async fn connect_raw<S, T>(
         &self,
         stream: S,
@@ -782,6 +810,7 @@ impl fmt::Debug for Config {
             .field("hostaddr", &self.hostaddr)
             .field("port", &self.port)
             .field("connect_timeout", &self.connect_timeout)
+            .field("buffer_size", &self.buffer_size)
             .field("tcp_user_timeout", &self.tcp_user_timeout)
             .field("keepalives", &self.keepalives);
 
@@ -1201,5 +1230,21 @@ mod tests {
     fn test_invalid_hostaddr_parsing() {
         let s = "user=pass_user dbname=postgres host=host1 hostaddr=127.0.0 port=26257";
         s.parse::<Config>().err().unwrap();
+    }
+
+    #[test]
+    fn test_buffer_size_parsing() {
+        let config = Config::new();
+        assert_eq!(8192, config.get_buffer_size());
+
+        let config = "buffer_size=16384".parse::<Config>().unwrap();
+        assert_eq!(16384, config.get_buffer_size());
+
+        let config = "postgresql://localhost?buffer_size=32768"
+            .parse::<Config>()
+            .unwrap();
+        assert_eq!(32768, config.get_buffer_size());
+
+        "buffer_size=0".parse::<Config>().err().unwrap();
     }
 }

--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -656,9 +656,6 @@ impl Config {
                 let buffer_size = value
                     .parse::<usize>()
                     .map_err(|_| Error::config_parse(Box::new(InvalidValue("buffer_size"))))?;
-                if buffer_size == 0 {
-                    return Err(Error::config_parse(Box::new(InvalidValue("buffer_size"))));
-                }
                 self.buffer_size(buffer_size);
             }
             "tcp_user_timeout" => {
@@ -1245,6 +1242,7 @@ mod tests {
             .unwrap();
         assert_eq!(32768, config.get_buffer_size());
 
-        "buffer_size=0".parse::<Config>().err().unwrap();
+        let config = "buffer_size=0".parse::<Config>().unwrap();
+        assert_eq!(0, config.get_buffer_size());
     }
 }

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -99,8 +99,8 @@ where
     .await?;
 
     let mut stream = StartupStream {
-        inner: Framed::new(stream, PostgresCodec),
-        buf: BackendMessages::empty(),
+        inner: Framed::with_capacity(stream, PostgresCodec, config.buffer_size),
+        buf: BackendMessages::with_capacity(config.buffer_size),
         delayed: VecDeque::new(),
     };
 
@@ -120,6 +120,7 @@ where
         config.ssl_negotiation,
         process_id,
         secret_key,
+        config.buffer_size,
     );
     let connection = Connection::new(stream.inner, stream.delayed, parameters, receiver);
 

--- a/tokio-postgres/src/connect_raw.rs
+++ b/tokio-postgres/src/connect_raw.rs
@@ -99,7 +99,11 @@ where
     .await?;
 
     let mut stream = StartupStream {
-        inner: Framed::with_capacity(stream, PostgresCodec, config.buffer_size),
+        inner: Framed::with_capacity(
+            stream,
+            PostgresCodec::new(config.buffer_size),
+            config.buffer_size,
+        ),
         buf: BackendMessages::with_capacity(config.buffer_size),
         delayed: VecDeque::new(),
     };

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -6,14 +6,14 @@ use crate::{AsyncMessage, Error, Notification};
 use bytes::BytesMut;
 use fallible_iterator::FallibleIterator;
 use futures_channel::mpsc;
-use futures_util::{stream::FusedStream, Sink, Stream, StreamExt};
+use futures_util::{Sink, Stream, StreamExt, stream::FusedStream};
 use log::{info, trace};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{ready, Context, Poll};
+use std::task::{Context, Poll, ready};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 

--- a/tokio-postgres/src/connection.rs
+++ b/tokio-postgres/src/connection.rs
@@ -6,14 +6,14 @@ use crate::{AsyncMessage, Error, Notification};
 use bytes::BytesMut;
 use fallible_iterator::FallibleIterator;
 use futures_channel::mpsc;
-use futures_util::{Sink, Stream, StreamExt, stream::FusedStream};
+use futures_util::{stream::FusedStream, Sink, Stream, StreamExt};
 use log::{info, trace};
 use postgres_protocol::message::backend::Message;
 use postgres_protocol::message::frontend;
 use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll, ready};
+use std::task::{ready, Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::codec::Framed;
 
@@ -277,7 +277,6 @@ where
         if self.state != State::Closing {
             return Poll::Pending;
         }
-
         match Pin::new(&mut self.stream)
             .poll_close(cx)
             .map_err(Error::io)?
@@ -298,6 +297,38 @@ where
         self.parameters.get(name).map(|s| &**s)
     }
 
+    /// Reclaim the `Framed` read/write buffers back down to the codec's
+    /// configured bound once the connection has gone fully idle.
+    ///
+    /// `Framed` grows its buffers to fit the largest message seen and never
+    /// shrinks them, so one large result set or bulk write would pin that
+    /// capacity for a pooled connection's whole lifetime. Only empty buffers
+    /// grown past the bound are reclaimed, so no in-flight bytes are dropped
+    /// and an already-bounded buffer won't churn allocations on the hot path.
+    fn reclaim_idle_buffers(&mut self) {
+        // Only when all in-flight work has drained, i.e. the connection is
+        // parked waiting for the next request (its state in the pool).
+        if self.state != State::Active
+            || !self.responses.is_empty()
+            || !self.pending_responses.is_empty()
+            || self.pending_request.is_some()
+        {
+            return;
+        }
+
+        let bound = self.stream.codec().max_buffer_size();
+
+        let read_buf = self.stream.read_buffer_mut();
+        if read_buf.is_empty() && read_buf.capacity() > bound {
+            *read_buf = BytesMut::with_capacity(bound);
+        }
+
+        let write_buf = self.stream.write_buffer_mut();
+        if write_buf.is_empty() && write_buf.capacity() > bound {
+            *write_buf = BytesMut::with_capacity(bound);
+        }
+    }
+
     fn poll_message_inner(
         &mut self,
         cx: &mut Context<'_>,
@@ -309,11 +340,17 @@ where
         }
         match message {
             Some(message) => Poll::Ready(Some(Ok(message))),
-            None => match self.poll_shutdown(cx) {
-                Poll::Ready(Ok(())) => Poll::Ready(None),
-                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
-                Poll::Pending => Poll::Pending,
-            },
+            None => {
+                // No synchronous message this round. If the connection has gone
+                // fully idle, reclaim any oversized `Framed` buffers before it
+                // parks back in the pool.
+                self.reclaim_idle_buffers();
+                match self.poll_shutdown(cx) {
+                    Poll::Ready(Ok(())) => Poll::Ready(None),
+                    Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 
@@ -352,5 +389,74 @@ where
             }
         }
         Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::PostgresCodec;
+    use tokio::io::DuplexStream;
+    use tokio_util::codec::Framed;
+
+    /// Number of bytes the test buffers are grown to before reclaim — well past
+    /// the configured bound so the reclaim path is exercised.
+    const GROWN: usize = 1024 * 1024;
+    /// Reclaim bound used by the test codec.
+    const BOUND: usize = 256;
+
+    type TestConnection = Connection<DuplexStream, DuplexStream>;
+
+    /// Build an idle `Connection` backed by an in-memory duplex stream whose
+    /// `Framed` read/write buffers have been grown past `BOUND`.
+    fn idle_connection() -> TestConnection {
+        let (client_side, _server_side) = tokio::io::duplex(64);
+        let framed = Framed::new(MaybeTlsStream::Raw(client_side), PostgresCodec::new(BOUND));
+        let (_sender, receiver) = mpsc::unbounded();
+        let mut conn = Connection::new(framed, VecDeque::new(), HashMap::new(), receiver);
+        conn.stream.read_buffer_mut().reserve(GROWN);
+        conn.stream.write_buffer_mut().reserve(GROWN);
+        conn
+    }
+
+    /// An idle connection with empty-but-oversized buffers reclaims both back
+    /// down to the configured bound.
+    #[test]
+    fn reclaims_oversized_buffers_when_idle() {
+        let mut conn = idle_connection();
+        assert!(conn.stream.read_buffer().capacity() >= GROWN);
+        assert!(conn.stream.write_buffer().capacity() >= GROWN);
+
+        conn.reclaim_idle_buffers();
+
+        assert!(conn.stream.read_buffer().capacity() <= BOUND);
+        assert!(conn.stream.write_buffer().capacity() <= BOUND);
+    }
+
+    /// A non-empty read buffer (a partial frame is still buffered) must not be
+    /// reclaimed, otherwise the pending bytes would be lost.
+    #[test]
+    fn keeps_nonempty_read_buffer() {
+        let mut conn = idle_connection();
+        conn.stream.read_buffer_mut().extend_from_slice(b"partial");
+
+        conn.reclaim_idle_buffers();
+
+        assert!(conn.stream.read_buffer().capacity() >= GROWN);
+    }
+
+    /// A connection that still has in-flight work (a pending request) is not
+    /// idle and must keep its buffers untouched.
+    #[test]
+    fn skips_reclaim_when_request_pending() {
+        let mut conn = idle_connection();
+        conn.pending_request = Some(RequestMessages::Single(FrontendMessage::Raw(
+            bytes::Bytes::new(),
+        )));
+
+        conn.reclaim_idle_buffers();
+
+        assert!(conn.stream.read_buffer().capacity() >= GROWN);
+        assert!(conn.stream.write_buffer().capacity() >= GROWN);
     }
 }


### PR DESCRIPTION
This PR reduces memory retained by long-lived `tokio-postgres` connections after unusually large reads or writes. This fixes issue #1081 

Previously, several internal `BytesMut` buffers could grow to handle a large response or request and then keep that allocation for the lifetime of the connection, even after the data had been fully consumed. This could make connection memory usage remain high after one large query, COPY operation, or encoded request.

The fix introduces a configurable `buffer_size` connection setting, defaulting to `8192`, and uses it as the target retained capacity for connection buffers.

**Changes**
- Adds `Config::buffer_size(...)` and `Config::get_buffer_size()`.
- Adds `buffer_size` support to connection strings and URL parameters:
  - `buffer_size=16384`
  - `postgresql://localhost?buffer_size=16384`
- Uses `Framed::with_capacity(..., config.buffer_size)` when constructing the connection stream.
- Initializes `BackendMessages` and client write buffers with the configured size.
- Drops oversized drained response batches before waiting for the next batch.
- Drops oversized client write scratch buffers after `InnerClient::with_buf` completes.
- Adds deterministic unit tests for the memory-retention paths.

**Why**
`BytesMut::clear()` resets length but does not release capacity. Similarly, a drained `BackendMessages` could continue holding a large allocation while a `Responses` object waited for more data. On long-lived connections, these retained allocations could look like memory growth that never recovers after large operations.

**Testing**
Added tests covering:
- Drained oversized backend response batches are reduced back to the configured buffer size.
- Oversized client write scratch buffers are reduced after use.
- `buffer_size` parsing for key-value and URL connection strings.
- Invalid `buffer_size=0` is rejected.