### PR TITLE
Add host fallback of `/run/postgresql` on Unix

### DIFF
--- a/tokio-postgres/src/config.rs
+++ b/tokio-postgres/src/config.rs
@@ -369,7 +369,13 @@ impl Config {
     ///
     /// Multiple hosts can be specified by calling this method multiple times, and each will be tried in order. On Unix
     /// systems, a host starting with a `/` is interpreted as a path to a directory containing Unix domain sockets.
-    /// There must be either no hosts, or the same number of hosts as hostaddrs.
+    ///
+    /// On Unix systems, when [`connect`] is called an empty host string will be interpreted as `/run/postgresql` if
+    /// and only if the `hostaddr` vec is empty. This is done at connect time because at configure time we cannot be
+    /// sure that a `hostaddr` will not be added later, and doing so would force every connection to TCP where we want
+    /// to preserve the empty host name.
+    ///
+    /// If there are hostaddrs, then there must be either no hosts, or the same number of hosts as hostaddrs.
     pub fn host(&mut self, host: impl Into<String>) -> &mut Config {
         let host = host.into();
 

--- a/tokio-postgres/src/connect.rs
+++ b/tokio-postgres/src/connect.rs
@@ -12,6 +12,12 @@ use std::task::Poll;
 use std::{cmp, io};
 use tokio::net;
 
+#[cfg(unix)]
+/// The fallback unix socket path for when `host` is `None` or the empty string.
+///
+/// Used only when the `hostaddr` vec is empty.
+const UNIX_FALLBACK: &str = "/run/postgresql";
+
 pub async fn connect<T>(
     mut tls: T,
     config: &Config,
@@ -19,6 +25,7 @@ pub async fn connect<T>(
 where
     T: MakeTlsConnect<Socket>,
 {
+    #[cfg(not(unix))]
     if config.host.is_empty() && config.hostaddr.is_empty() {
         return Err(Error::config("both host and hostaddr are missing".into()));
     }
@@ -36,13 +43,16 @@ where
     }
 
     // At this point, either one of the following two scenarios could happen:
-    // (1) either config.host or config.hostaddr must be empty;
+    // (1) either config.host or config.hostaddr (or both) must be empty;
     // (2) if both config.host and config.hostaddr are NOT empty; their lengths must be equal.
     let num_hosts = cmp::max(config.host.len(), config.hostaddr.len());
 
     if config.port.len() > 1 && config.port.len() != num_hosts {
         return Err(Error::config("invalid number of ports".into()));
     }
+
+    // If everything is empty, attempt 1 connection with the default values.
+    let num_hosts = cmp::max(num_hosts, 1);
 
     let mut indices = (0..num_hosts).collect::<Vec<_>>();
     if config.load_balance_hosts == LoadBalanceHosts::Random {
@@ -73,7 +83,15 @@ where
         // fallback to host if hostaddr is not present.
         let addr = match hostaddr {
             Some(ipaddr) => Host::Tcp(ipaddr.to_string()),
+            #[cfg(not(unix))]
+            // Will not panic, with this cfg we've errored above if both hostaddr and host are empty
             None => host.cloned().unwrap(),
+            #[cfg(unix)]
+            None => match host {
+                None => Host::Unix(UNIX_FALLBACK.into()),
+                Some(Host::Tcp(s)) if s.is_empty() => Host::Unix(UNIX_FALLBACK.into()),
+                Some(host) => host.clone(),
+            },
         };
 
         match connect_host(addr, hostname, port, &mut tls, config).await {

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -24,21 +24,42 @@ async fn smoke_test(s: &str) {
 #[ignore] // FIXME doesn't work with our docker-based tests :(
 async fn unix_socket() {
     smoke_test("host=/var/run/postgresql port=5433 user=postgres").await;
+    smoke_test("postgres://postgres@%2Frun%2Fpostgresql:5433/").await;
+    smoke_test("postgres://postgres@/?host=/run/postgresql&port=5433").await;
+
+    // `host` is `None` -> error cause: "both host and hostaddr are missing"
+    // smoke_test("port=5433 user=postgres").await;
+    // smoke_test("postgres://postgres@/?port=5433").await;
+
+    // `host` is "" -> error cause: "failed to lookup address information: No address associated with hostname"
+    // smoke_test("host='' port=5433 user=postgres").await;
+    // smoke_test("postgres://postgres@/?host=&port=5433").await;
+    // smoke_test("postgres://postgres@:5433").await;
+    // smoke_test("postgres://postgres@:5433,:5433").await;
+
+    // Currently these will always fail when looking up the empty hostname, and then attempt the
+    // intended host. If a fallback domain socket is added, then the empty host could turn from a
+    // silent failure into a successful domain socket connection.
+    smoke_test("host=,/run/postgresql port=5433 user=postgres").await;
+    smoke_test("postgres://postgres@:5433/?host=/run/postgresql").await;
 }
 
 #[tokio::test]
 async fn tcp() {
     smoke_test("host=localhost port=5433 user=postgres").await;
+    smoke_test("postgres://postgres@localhost:5433/").await;
 }
 
 #[tokio::test]
 async fn multiple_hosts_one_port() {
     smoke_test("host=foobar.invalid,localhost port=5433 user=postgres").await;
+    smoke_test("postgres:///?port=5433&host=foobar.invalid&host=localhost&user=postgres").await;
 }
 
 #[tokio::test]
 async fn multiple_hosts_multiple_ports() {
     smoke_test("host=foobar.invalid,localhost port=5432,5433 user=postgres").await;
+    smoke_test("postgres://postgres@foobar.invalid:5432,localhost:5433/").await;
 }
 
 #[tokio::test]
@@ -47,11 +68,19 @@ async fn wrong_port_count() {
         .await
         .err()
         .unwrap();
+
+    // An implicit default port is provided when a host (`localhost` here) is provided, resulting
+    // in 2 ports and only 1 host.
+    tokio_postgres::connect("postgres://localhost/?port=5433&user=postgres", NoTls)
+        .await
+        .err()
+        .unwrap();
 }
 
 #[tokio::test]
 async fn target_session_attrs_ok() {
     smoke_test("host=localhost port=5433 user=postgres target_session_attrs=read-write").await;
+    smoke_test("postgres://postgres@localhost:5433/?target_session_attrs=read-write").await;
 }
 
 #[tokio::test]
@@ -74,12 +103,51 @@ async fn host_only_ok() {
     )
     .await
     .unwrap();
+
+    let _ = tokio_postgres::connect(
+        "postgres://pass_user:password@localhost:5433/postgres",
+        NoTls,
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn hostaddr_only_ok() {
     let _ = tokio_postgres::connect(
         "hostaddr=127.0.0.1 port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .unwrap();
+
+    let _ = tokio_postgres::connect(
+        "postgres:///?hostaddr=127.0.0.1&port=5433&user=pass_user&dbname=postgres&password=password",
+        NoTls,
+    )
+    .await
+    .unwrap();
+
+    let _ = tokio_postgres::connect(
+        "postgres://pass_user:password@/postgres?hostaddr=127.0.0.1&port=5433",
+        NoTls,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn hostaddr_with_empty_host_ok() {
+    let _ = tokio_postgres::connect(
+        "host='' hostaddr=127.0.0.1 port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .unwrap();
+
+    // The `host` is implicitly set to "" because of the `:port` portion is present.
+    let _ = tokio_postgres::connect(
+        "postgres://pass_user:password@:5433/postgres?hostaddr=127.0.0.1",
         NoTls,
     )
     .await
@@ -94,12 +162,27 @@ async fn hostaddr_and_host_ok() {
     )
     .await
     .unwrap();
+
+    let _ = tokio_postgres::connect(
+        "postgres://pass_user:password@localhost:5433/postgres?hostaddr=127.0.0.1",
+        NoTls,
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn hostaddr_host_mismatch() {
     let _ = tokio_postgres::connect(
         "hostaddr=127.0.0.1,127.0.0.2 host=localhost port=5433 user=pass_user dbname=postgres password=password",
+        NoTls,
+    )
+    .await
+    .err()
+    .unwrap();
+
+    let _ = tokio_postgres::connect(
+        "postgres://pass_user:password@localhost:5433/postgres?hostaddr=127.0.0.1,127.0.0.2",
         NoTls,
     )
     .await
@@ -116,6 +199,11 @@ async fn hostaddr_host_both_missing() {
     .await
     .err()
     .unwrap();
+
+    let _ = tokio_postgres::connect("postgres://pass_user:password@/postgres?port=5433", NoTls)
+        .await
+        .err()
+        .unwrap();
 }
 
 #[tokio::test]

--- a/tokio-postgres/tests/test/runtime.rs
+++ b/tokio-postgres/tests/test/runtime.rs
@@ -27,21 +27,23 @@ async fn unix_socket() {
     smoke_test("postgres://postgres@%2Frun%2Fpostgresql:5433/").await;
     smoke_test("postgres://postgres@/?host=/run/postgresql&port=5433").await;
 
-    // `host` is `None` -> error cause: "both host and hostaddr are missing"
-    // smoke_test("port=5433 user=postgres").await;
-    // smoke_test("postgres://postgres@/?port=5433").await;
+    // Fallback to default socket path when `host` is `None`
+    // (on non-unix, error cause: "both host and hostaddr are missing")
+    smoke_test("port=5433 user=postgres").await;
+    smoke_test("postgres://postgres@/?port=5433").await;
 
-    // `host` is "" -> error cause: "failed to lookup address information: No address associated with hostname"
-    // smoke_test("host='' port=5433 user=postgres").await;
-    // smoke_test("postgres://postgres@/?host=&port=5433").await;
-    // smoke_test("postgres://postgres@:5433").await;
-    // smoke_test("postgres://postgres@:5433,:5433").await;
+    // Fallback to default socket path when `host` is ""
+    // (on non-unix, error cause: "failed to lookup address information: No address associated with hostname")
+    smoke_test("host='' port=5433 user=postgres").await;
+    smoke_test("postgres://postgres@/?host=&port=5433").await;
+    smoke_test("postgres://postgres@:5433").await;
+    smoke_test("postgres://postgres@:5433,:5433").await;
 
-    // Currently these will always fail when looking up the empty hostname, and then attempt the
-    // intended host. If a fallback domain socket is added, then the empty host could turn from a
-    // silent failure into a successful domain socket connection.
-    smoke_test("host=,/run/postgresql port=5433 user=postgres").await;
-    smoke_test("postgres://postgres@:5433/?host=/run/postgresql").await;
+    // Previously these would always fail when looking up the empty hostname, and then attempt the
+    // intended host. With a fallback path now in place, the empty host is no longer a silent
+    // failure and may result in a successful connection to the fallback host path.
+    smoke_test("host=,/does/not/exist port=5433 user=postgres").await;
+    smoke_test("postgres://postgres@:5433/?host=/does/not/exist").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
This implements a fallback unix socket path when the host is empty, allowing for shorthand such as `postgres:///` to connect with all default parameters.

There is one subtle change in behavior. Previously `host=,/does/not/exist port=5433 user=postgres` and `postgres://postgres@:5433/?host=/does/not/exist` would first attempt a TCP connection to an empty host name and then try the 2nd host. Now, it could successfully connect to the fallback path. In the former case it already looks weird with the comma, but in the latter case the first host is much more implicit. Thus, its not clear to me if this would be an acceptable change in a point release.

Probably closes #82, though the basing the fallback on environment variables was not implemented.